### PR TITLE
Add vm.overcommit memory to sysctl

### DIFF
--- a/redis/defaults/main.yml
+++ b/redis/defaults/main.yml
@@ -1,0 +1,1 @@
+redis_overcommit_memory: false

--- a/redis/handlers/main.yml
+++ b/redis/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart redis
+- name: Restart Redis
   service:
     name: redis-server
     state: restarted

--- a/redis/tasks/main.yml
+++ b/redis/tasks/main.yml
@@ -1,7 +1,13 @@
 ---
-- name: Install redis
+- name: Install Redis
   apt:
     pkg: redis-server
     state: present
     update_cache: yes
     cache_valid_time: 3600
+
+- name: Add vm.overcommit_memory = 1 to sysctl
+  sysctl:
+    name: vm.overcommit_memory
+    value: 1
+    reload: yes

--- a/redis/tasks/main.yml
+++ b/redis/tasks/main.yml
@@ -11,3 +11,4 @@
     name: vm.overcommit_memory
     value: 1
     reload: yes
+  when: redis_overcommit_memory


### PR DESCRIPTION
This is pretty much recommended behaviour here https://redis.io/topics/faq so thought just put it into the core role.