### PR TITLE
Add ansible-lint workflow and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,16 @@
+name: ansible-lint
+
+on:
+  push:
+    branches: ["bookworm"]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@main
+        with:
+          requirements_file: requirements.yml


### PR DESCRIPTION
## Summary
- run ansible-lint in GitHub Actions using the `ansible/ansible-lint` action
- set workflow to run for pushes to the `bookworm` branch and all PRs
- configure Dependabot for GitHub Actions updates

## Testing
- `ansible-lint` *(fails with 98 failures)*

------
https://chatgpt.com/codex/tasks/task_e_685977492f30832d990c327ef86595f0