### PR TITLE
Add AGENTS install steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS Configuration
+
+## Scope
+This configuration applies to the entire repository.
+
+## Testing
+Install `ansible-dev-tools` with `pipx`, which includes `ansible` and `ansible-lint`:
+
+```
+pipx install --include-deps ansible-dev-tools
+```
+
+Install collection dependencies listed in `requirements.yml`:
+
+```
+ansible-galaxy collection install -r requirements.yml
+```
+
+Run `ansible-lint` before committing changes. If Docker is available you can also run `make lint` which uses the official ansible-lint container.
+
+## YAML style
+Use two-space indentation for YAML and Ansible files.
+
+## Commit messages
+Write concise commit messages describing why the change is made.
+


### PR DESCRIPTION
## Summary
- document pipx install of ansible-dev-tools
- keep instructions to install collection dependencies from `requirements.yml`
- note that `pipx install` should include dependencies with `--include-deps`

## Testing
- `ansible-galaxy collection install -r requirements.yml`
- `ansible-lint` *(fails: 98 failure(s))*

------
https://chatgpt.com/codex/tasks/task_e_6859777d8478832db32f036c88d108f1