### PR TITLE
pgsql: schema support and configurable become user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+### Added
+
+- **pgsql:** add `postgres_schemas` variable to create schemas, and
+  `schema`/`target_roles` keys in `postgres_privs` for schema-scoped and
+  default-privilege grants
+
 ## [1.0.0] - 2026-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 - **pgsql:** add `postgres_schemas` variable to create schemas, and
   `schema`/`target_roles` keys in `postgres_privs` for schema-scoped and
   default-privilege grants
+- **pgsql:** add `postgres_become_user` variable (default `postgres`) to configure the
+  system user that database operations run as
 
 ## [1.0.0] - 2026-06-11
 

--- a/roles/pgsql/README.md
+++ b/roles/pgsql/README.md
@@ -11,6 +11,7 @@ Installs and configures PostgreSQL server.
 | `postgres_schemas` | `[]` | Schemas to create (keys: `db`, `name`, `owner`) |
 | `postgres_privs` | `[]` | Privileges to grant (keys: `db`, `roles`, `privs`, `type`, `objs`, `schema`, `target_roles`) |
 | `postgres_extensions` | `[]` | Extensions to enable |
+| `postgres_become_user` | `postgres` | System user to run database operations as |
 | `postgres_default_packages` | See defaults | PostgreSQL packages to install |
 | `postgres_additional_packages` | `[]` | Additional packages to install |
 | `postgres_shared_buffers` | `512MB` | Shared buffers size (1/4 RAM) |

--- a/roles/pgsql/README.md
+++ b/roles/pgsql/README.md
@@ -8,7 +8,8 @@ Installs and configures PostgreSQL server.
 |----------|---------|-------------|
 | `postgres_databases` | `[]` | Databases to create |
 | `postgres_users` | `[]` | Users to create |
-| `postgres_privs` | `[]` | Privileges to grant |
+| `postgres_schemas` | `[]` | Schemas to create (keys: `db`, `name`, `owner`) |
+| `postgres_privs` | `[]` | Privileges to grant (keys: `db`, `roles`, `privs`, `type`, `objs`, `schema`, `target_roles`) |
 | `postgres_extensions` | `[]` | Extensions to enable |
 | `postgres_default_packages` | See defaults | PostgreSQL packages to install |
 | `postgres_additional_packages` | `[]` | Additional packages to install |

--- a/roles/pgsql/defaults/main.yml
+++ b/roles/pgsql/defaults/main.yml
@@ -4,6 +4,7 @@ postgres_users: []
 postgres_schemas: []
 postgres_privs: []
 postgres_extensions: []
+postgres_become_user: postgres
 postgres_default_packages:
   - "postgresql-{{ postgres_version }}"
   - "postgresql-client-{{ postgres_version }}"

--- a/roles/pgsql/defaults/main.yml
+++ b/roles/pgsql/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 postgres_databases: []
 postgres_users: []
+postgres_schemas: []
 postgres_privs: []
 postgres_extensions: []
 postgres_default_packages:

--- a/roles/pgsql/tasks/main.yml
+++ b/roles/pgsql/tasks/main.yml
@@ -66,6 +66,15 @@
   no_log: true
   with_items: "{{ postgres_users }}"
 
+- name: Create schemas
+  become: true
+  become_user: postgres
+  community.postgresql.postgresql_schema:
+    db: "{{ item.db }}"
+    name: "{{ item.name }}"
+    owner: "{{ item.owner | default(omit) }}"
+  with_items: "{{ postgres_schemas }}"
+
 - name: Apply privs
   become: true
   become_user: postgres
@@ -75,6 +84,8 @@
     privs: "{{ item.privs }}"
     type: "{{ item.type | default(omit) }}"
     objs: "{{ item.objs | default(omit) }}"
+    schema: "{{ item.schema | default(omit) }}"
+    target_roles: "{{ item.target_roles | default(omit) }}"
   with_items: "{{ postgres_privs }}"
 
 - name: Enable extensions

--- a/roles/pgsql/tasks/main.yml
+++ b/roles/pgsql/tasks/main.yml
@@ -49,7 +49,7 @@
 
 - name: Create databases
   become: true
-  become_user: postgres
+  become_user: "{{ postgres_become_user }}"
   community.postgresql.postgresql_db:
     name: "{{ item }}"
     state: present
@@ -57,7 +57,7 @@
 
 - name: Create users
   become: true
-  become_user: postgres
+  become_user: "{{ postgres_become_user }}"
   community.postgresql.postgresql_user:
     name: "{{ item.user }}"
     password: "{{ item.password }}"
@@ -68,7 +68,7 @@
 
 - name: Create schemas
   become: true
-  become_user: postgres
+  become_user: "{{ postgres_become_user }}"
   community.postgresql.postgresql_schema:
     db: "{{ item.db }}"
     name: "{{ item.name }}"
@@ -77,7 +77,7 @@
 
 - name: Apply privs
   become: true
-  become_user: postgres
+  become_user: "{{ postgres_become_user }}"
   community.postgresql.postgresql_privs:
     database: "{{ item.db }}"
     roles: "{{ item.roles }}"
@@ -90,7 +90,7 @@
 
 - name: Enable extensions
   become: true
-  become_user: postgres
+  become_user: "{{ postgres_become_user }}"
   community.postgresql.postgresql_ext:
     name: "{{ item.name }}"
     db: "{{ item.db }}"


### PR DESCRIPTION
## Summary

Extends the `pgsql` role with PostgreSQL schema management and a configurable become user.

- Add `postgres_schemas` variable to create schemas (keys: `db`, `name`, `owner`).
- Add `schema`/`target_roles` keys to `postgres_privs` for schema-scoped and default-privilege grants (e.g. `ALTER DEFAULT PRIVILEGES FOR ROLE ...`).
- Extract the hardcoded `become_user: postgres` from all database tasks into a new `postgres_become_user` variable (default `postgres`).

## Changelog

- [x] Added entries under `## [Unreleased]` in `CHANGELOG.md`, prefixed with `**pgsql:**`.
- [x] No **BREAKING** changes — all additions are backward compatible (empty-list / `default(omit)` / unchanged default user).

## Version impact (SemVer)

- MINOR — new variables (`postgres_schemas`, `postgres_become_user`) and new optional `postgres_privs` keys; no change to existing default behaviour.