### PR TITLE
php_cli, php_fpm: accept unquoted YAML version in support check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ flagged with **BREAKING** and require a MAJOR version bump.
   renamed `ansible.mysql` collection. Consumers of `tborealis.roles` must now install the
   `ansible.mysql` collection.
 
+### Fixed
+
+- **php_cli, php_fpm:** accept an unquoted YAML version (e.g. `php_version: 8.1`
+  parsed as a float) in the supported-version check by coercing to a string before
+  comparison
+
 ## [1.0.0] - 2026-06-11
 
 ### Added

--- a/roles/php_cli/tasks/main.yml
+++ b/roles/php_cli/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Validate PHP CLI version is supported
   ansible.builtin.assert:
-    that: php_cli_version in php_cli_supported_versions
+    that: php_cli_version | string in php_cli_supported_versions
     fail_msg: "Unsupported PHP CLI version '{{ php_cli_version }}'. Supported: {{ php_cli_supported_versions | join(', ') }}"
 
 - name: Install PHP CLI

--- a/roles/php_fpm/tasks/main.yml
+++ b/roles/php_fpm/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Validate PHP FPM version is supported
   ansible.builtin.assert:
-    that: php_fpm_version in php_fpm_supported_versions
+    that: php_fpm_version | string in php_fpm_supported_versions
     fail_msg: "Unsupported PHP FPM version '{{ php_fpm_version }}'. Supported: {{ php_fpm_supported_versions | join(', ') }}"
 
 - name: Install PHP FPM


### PR DESCRIPTION
## Summary

Running the `php_cli` (or `php_fpm`) role with an unquoted version such as
`php_version: 8.1` failed validation with a confusing message:

> Unsupported PHP CLI version '8.1'. Supported: 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5

The cause is YAML type coercion: an unquoted `8.1` is parsed as a **float**, while
`php_cli_supported_versions` is a list of **strings**, so `version in supported_versions`
is always `False` even when the value visually matches.

## Change

Cast the version to a string before the membership test in both roles:

- `php_cli_version | string in php_cli_supported_versions`
- `php_fpm_version | string in php_fpm_supported_versions`

Quoting the version at the source still works as before; this just makes the check
tolerant of the common unquoted-float mistake.

## Notes

- `make lint` passes (0 failures, 0 warnings).
- Not a breaking change — strictly widens what the assertion accepts.
- Changelog updated under `### Fixed`.