### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-06-12
+
 ### Added
 
 - **pgsql:** add `postgres_schemas` variable to create schemas, and

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 1.0.0
+version: 2.0.0
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
Cuts the **v2.0.0** release: bumps `galaxy.yml` to `2.0.0` and promotes the `[Unreleased]` changelog section to `## [2.0.0] - 2026-06-12`.

**MAJOR bump** — the release contains a breaking change:

- **mysql:** switch from the deprecated `community.mysql` collection to the renamed `ansible.mysql` collection. Consumers of `tborealis.roles` must now install the `ansible.mysql` collection.

Other notable changes in this release:

- **Added** — `pgsql` schema support (`postgres_schemas`, `schema`/`target_roles` privs) and configurable `postgres_become_user`.
- **Changed** — migrate `apt_repository`/`apt_key` usage off deprecated modules to `deb822_repository` across base, do_agent, mysql, new_relic, nginx, node, pgsql(+client), php_repo_sury, rabbitmq, yarn, and the shared add-key helper; refresh the yarn signing key.
- **Fixed** — `php_cli`/`php_fpm` accept an unquoted YAML version in the supported-version check.

After merge, tag `main` with `v2.0.0` and push the tag to trigger the release workflow.