### PR TITLE
pgsql: replace deprecated db/database aliases with login_db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+### Fixed
+
+- **pgsql:** use the canonical `login_db` parameter for `postgresql_user`,
+  `postgresql_schema`, `postgresql_privs`, and `postgresql_ext` tasks, replacing the
+  deprecated `db`/`database` aliases (slated for removal in `community.postgresql` 5.0.0)
+
 ## [2.0.0] - 2026-06-12
 
 ### Added

--- a/roles/pgsql/tasks/main.yml
+++ b/roles/pgsql/tasks/main.yml
@@ -88,7 +88,7 @@
   community.postgresql.postgresql_user:
     name: "{{ item.user }}"
     password: "{{ item.password }}"
-    db: "{{ item.db | default(omit) }}"
+    login_db: "{{ item.db | default(omit) }}"
     priv: "{{ item.priv | default(omit) }}"
   no_log: true
   with_items: "{{ postgres_users }}"
@@ -97,7 +97,7 @@
   become: true
   become_user: "{{ postgres_become_user }}"
   community.postgresql.postgresql_schema:
-    db: "{{ item.db }}"
+    login_db: "{{ item.db }}"
     name: "{{ item.name }}"
     owner: "{{ item.owner | default(omit) }}"
   with_items: "{{ postgres_schemas }}"
@@ -106,7 +106,7 @@
   become: true
   become_user: "{{ postgres_become_user }}"
   community.postgresql.postgresql_privs:
-    database: "{{ item.db }}"
+    login_db: "{{ item.db }}"
     roles: "{{ item.roles }}"
     privs: "{{ item.privs }}"
     type: "{{ item.type | default(omit) }}"
@@ -120,5 +120,5 @@
   become_user: "{{ postgres_become_user }}"
   community.postgresql.postgresql_ext:
     name: "{{ item.name }}"
-    db: "{{ item.db }}"
+    login_db: "{{ item.db }}"
   with_items: "{{ postgres_extensions }}"


### PR DESCRIPTION
## Summary

Running the `pgsql` role emits a `community.postgresql` deprecation warning:

> Alias 'database' is deprecated. ... This feature will be removed from collection 'community.postgresql' version 5.0.0.

The `community.postgresql` modules standardised on `login_db` as the canonical database-connection parameter; the older `db`/`database` aliases are deprecated and **slated for removal in community.postgresql 5.0.0** (at which point these tasks would fail, not just warn). The collection is depended on unpinned (`community.postgresql: '*'`), so the 5.0.0 upgrade will happen automatically.

The warning surfaced on the `Apply privs` task, but the same deprecated alias was used by three other tasks in the role, so all are fixed together.

## Changes

`roles/pgsql/tasks/main.yml` — rename the deprecated module parameter to `login_db` in four tasks (values unchanged):

- `Create users` (`postgresql_user`): `db:` → `login_db:`
- `Create schemas` (`postgresql_schema`): `db:` → `login_db:`
- `Apply privs` (`postgresql_privs`): `database:` → `login_db:`
- `Enable extensions` (`postgresql_ext`): `db:` → `login_db:`

`Create databases` (`postgresql_db`) already uses the canonical `name:` parameter and is left unchanged.

## Compatibility

Not breaking — only module parameter names change. The role's public variable interface (`postgres_privs`/`postgres_users`/etc. item keys such as `db`) is unchanged.

## Testing

- `make lint` passes (0 failures, 0 warnings; confirms `login_db` is valid in the installed community.postgresql 4.2.0).