### PR TITLE
Release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-06-12
+
 ### Fixed
 
 - **pgsql:** use the canonical `login_db` parameter for `postgresql_user`,

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 2.0.0
+version: 2.0.1
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
## Release v2.0.1

PATCH release.

- Bumps `galaxy.yml` to `2.0.1`
- Promotes `[Unreleased]` to `## [2.0.1] - 2026-06-12` in `CHANGELOG.md`

### Included since v2.0.0

#### Fixed
- **pgsql:** use the canonical `login_db` parameter for `postgresql_user`, `postgresql_schema`, `postgresql_privs`, and `postgresql_ext` tasks, replacing the deprecated `db`/`database` aliases (slated for removal in `community.postgresql` 5.0.0) — #91

Non-breaking: only module parameter names change; the role's public variable interface is unchanged.

After merge, tag `main` with `v2.0.1` and push the tag to trigger `release.yml` (verify + publish GitHub Release).