### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-06-12
+
 ### Added
 
 - **redis:** add `redis_version` to optionally pin a major or major.minor line (e.g.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 2.0.1
+version: 3.0.0
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
Cuts **v3.0.0** (MAJOR — breaking changes to the `redis` role).

Bumps `galaxy.yml` to 3.0.0 and promotes `[Unreleased]` to `## [3.0.0] - 2026-06-12`.

### Breaking
- **redis:** install from the official `packages.redis.io` repository instead of the distribution's own
- **redis:** bind to localhost (`127.0.0.1 -::1`) by default

See the changelog section for the full list of additions and changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)