### PR TITLE
Verify apt keys against bookworm and trixie

### DIFF
--- a/.github/workflows/key-check.yml
+++ b/.github/workflows/key-check.yml
@@ -17,27 +17,24 @@ env:
   SETUP: apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq gpg ca-certificates python3 python3-yaml >/dev/null
 
 jobs:
-  check:
+  # Whether a signature verifies depends on the release's apt (trixie's sequoia
+  # rejects SHA1 bindings, bookworm's gpgv does not), so the check runs once in
+  # each release's own container. The script auto-detects the container's release.
+  key-check:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release: [bookworm, trixie]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      # Drift (unregistered/missing keyring) and an already expired/revoked
-      # committed key are mistakes we own, so this gate blocks PRs.
-      - name: Static gate (drift + expiry/revocation)
+      - name: Check keys (${{ matrix.release }})
         run: |
-          docker run --rm -v "$PWD:/w" -w /w debian:trixie \
-            sh -c "$SETUP && python3 scripts/check_apt_keys.py --days 30"
-
-      # Upstream keys/repos can break independently of a PR, so live failures
-      # alert (scheduled) but never block a PR.
-      - name: Live repository verification
-        if: ${{ always() }}
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-        run: |
-          docker run --rm -v "$PWD:/w" -w /w debian:trixie \
+          docker run --rm -v "$PWD:/w" -w /w debian:${{ matrix.release }} \
             sh -c "$SETUP && python3 scripts/check_apt_keys.py --live --days 30 --report-file /w/key-report.txt"
 
+      # Scheduled/manual runs alert via Slack; PRs just surface the check result.
       - name: Notify Slack
         if: ${{ always() && github.event_name != 'pull_request' }}
         env:
@@ -47,5 +44,5 @@ jobs:
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "::warning::key alerts present but SLACK_WEBHOOK_URL is not set"; cat key-report.txt; exit 0
           fi
-          payload=$(python3 -c 'import json; print(json.dumps({"text": open("key-report.txt").read()}))')
+          payload=$(python3 -c 'import json,sys; print(json.dumps({"text": sys.stdin.read().rstrip()}))' < key-report.txt)
           curl -fsS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,10 @@ to a new role:
 
 The scheduled `key-check` workflow discovers keys from this manifest automatically — no
 CI changes are needed — and a drift check fails the build if a keyring file is added
-without a manifest entry (or vice versa). Slack alerts require a `SLACK_WEBHOOK_URL`
-repository secret. Run `make check-keys` to check expiry and live verification locally.
+without a manifest entry (or vice versa). The live verification runs against each
+supported Debian release (bookworm and trixie) in its own container, because whether a
+signature is accepted depends on that release's apt. Slack alerts require a
+`SLACK_WEBHOOK_URL` repository secret. Run `make check-keys` to run all checks locally.
 
 ## Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@ flagged with **BREAKING** and require a MAJOR version bump.
   per-playbook key fixes when a key has changed
 - **meta:** scheduled `key-check` workflow and `scripts/check_apt_keys.py` that warn 30
   days before a signing key expires, fail on revoked/expired keys, and verify each key
-  still validates its repository (catching upstream revocation, rotation, and signature
-  policy failures); alerts post to Slack via a `SLACK_WEBHOOK_URL` secret, and
-  `make check-keys` runs the same checks locally
+  still validates its repository on Debian bookworm and trixie (catching upstream
+  revocation, rotation, and signature policy failures); alerts post to Slack via a
+  `SLACK_WEBHOOK_URL` secret, and `make check-keys` runs the same checks locally
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,21 @@
 .PHONY: lint check-keys release
 
+# Packages each release container needs to run the key checker.
+APT_KEYS_SETUP = apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq gpg ca-certificates python3 python3-yaml
+
 lint:
 	docker run --rm -v $(PWD):/workdir -w /workdir python:3-slim \
 		sh -c "pip install -q -r requirements-dev.txt && ansible-galaxy install -r requirements.yml && ansible-lint"
 
+# The live check runs in each release's own container, because whether a
+# signature is accepted depends on that release's apt (trixie rejects SHA1
+# bindings, bookworm does not). The script auto-detects the container's release.
+RELEASES ?= bookworm trixie
 check-keys:
-	docker run --rm -e DEBIAN_FRONTEND=noninteractive -v $(PWD):/workdir -w /workdir debian:trixie \
-		sh -c "apt-get update -qq && apt-get install -y -qq gpg ca-certificates python3 python3-yaml && python3 scripts/check_apt_keys.py --live --days 30"
+	@for r in $(RELEASES); do echo "== $$r =="; \
+		docker run --rm -v $(PWD):/workdir -w /workdir debian:$$r \
+			sh -c "$(APT_KEYS_SETUP) && python3 scripts/check_apt_keys.py --live --days 30"; \
+	done
 
 release:
 ifndef VERSION

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ ansible-lint
 ```
 
 Run `make check-keys` to check the apt repository signing keys for expiry and to verify
-each one still validates its repository. A scheduled CI job runs the same checks weekly
-and posts to Slack when a key is expiring or no longer verifies.
+each one still validates its repository on Debian bookworm and trixie. A scheduled CI job
+runs the same checks weekly and posts to Slack when a key is expiring or no longer verifies.
 
 See `galaxy.yml` for collection metadata and dependencies.
 

--- a/scripts/check_apt_keys.py
+++ b/scripts/check_apt_keys.py
@@ -15,7 +15,11 @@ roles/apt_keys/defaults/main.yml:
   running `apt-get update` against it. Catches upstream revocation/rotation
   that static inspection cannot see. A genuine key failure (EXPKEYSIG /
   REVKEYSIG / KEYEXPIRED / NO_PUBKEY) is fatal; an unreachable repo or missing
-  suite is reported inconclusive, not fatal.
+  suite is reported inconclusive, not fatal. Whether a signature is accepted
+  depends on the apt of the Debian release this runs under (trixie's sequoia
+  apt rejects SHA1 bindings, bookworm's gpgv does not), so run it once inside
+  each debian:<release> image you care about — the suite codename is
+  auto-detected from there.
 
 Also guards against drift: every keyring file must be registered in the
 manifest and vice versa.
@@ -55,6 +59,17 @@ SIG_FAIL_MARKERS = (
 UNUSABLE_VALIDITY = {"e", "r", "i", "d"}  # expired, revoked, invalid, disabled
 
 OK, WARNING, CRITICAL, NOTICE = "OK", "WARNING", "CRITICAL", "NOTICE"
+
+
+def detect_release(default: str = "trixie") -> str:
+    """Return the running container's Debian codename, for matching suites."""
+    try:
+        for line in Path("/etc/os-release").read_text().splitlines():
+            if line.startswith("VERSION_CODENAME="):
+                return line.split("=", 1)[1].strip().strip('"') or default
+    except OSError:
+        pass
+    return default
 
 
 def load_entries(manifest: Path) -> list[dict]:
@@ -185,8 +200,9 @@ def main() -> int:
                         help="warn when a keyring's last usable key expires within N days")
     parser.add_argument("--live", action="store_true",
                         help="also run apt-get update against each repo (needs apt)")
-    parser.add_argument("--release", default="trixie",
-                        help="Debian release substituted for {release} in suites")
+    parser.add_argument("--release", default=None,
+                        help="Debian release for {release} in suites "
+                             "(default: the running container's codename)")
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument("--files-dir", type=Path, default=DEFAULT_FILES_DIR)
     parser.add_argument("--report-file", type=Path,
@@ -194,6 +210,7 @@ def main() -> int:
     args = parser.parse_args()
 
     entries = load_entries(args.manifest)
+    release = args.release or detect_release()
     alerts: list[str] = []
     has_critical = False
 
@@ -206,23 +223,22 @@ def main() -> int:
 
     width = max(len(e["name"]) for e in entries)
     for entry in entries:
-        keyring = args.files_dir / entry["src"]
-        status, detail = check_static(keyring, args.days)
-        line = f"{entry['name']:<{width}}  static    {status:<8}  {detail}"
-        print(line)
+        status, detail = check_static(args.files_dir / entry["src"], args.days)
+        print(f"{entry['name']:<{width}}  {'static':<14}  {status:<8}  {detail}")
         if status in (WARNING, CRITICAL):
             alerts.append(f"{entry['name']}: {detail}")
             has_critical = has_critical or status == CRITICAL
 
         if args.live:
-            lstatus, ldetail = check_live(entry, args.files_dir, args.release)
-            print(f"{entry['name']:<{width}}  live      {lstatus:<8}  {ldetail}")
+            lstatus, ldetail = check_live(entry, args.files_dir, release)
+            print(f"{entry['name']:<{width}}  {f'live[{release}]':<14}  {lstatus:<8}  {ldetail}")
             if lstatus == CRITICAL:
                 alerts.append(f"{entry['name']}: {ldetail}")
                 has_critical = True
 
     if args.report_file and alerts:
-        header = "apt key check found issues:\n"
+        scope = f" on {release}" if args.live else ""
+        header = f"apt key check found issues{scope}:\n"
         args.report_file.write_text(header + "\n".join(f"- {a}" for a in alerts) + "\n")
 
     if (gh_out := os.environ.get("GITHUB_OUTPUT")):


### PR DESCRIPTION
The live key verification only ran against trixie, but the fleet still includes bookworm servers. Whether a repository signature verifies depends on the release's apt (trixie's sequoia rejects SHA1 bindings, bookworm's gpgv does not), so the check must run inside each release's container.

- `check_apt_keys.py` auto-detects the container's Debian codename for the suite, so one release-agnostic check runs everywhere.
- `make check-keys` loops the releases; the `key-check` workflow runs them as a `[bookworm, trixie]` matrix, each posting its own Slack summary on scheduled runs.

Simpler than the first cut: no `--live-only`/static-gate machinery (the key-check isn't a required check, so it never blocked PRs anyway) — it's advisory (red ✗ + Slack on scheduled runs).

Verified with `make check-keys`: all keys `OK` on both releases (rabbitmq `NOTICE` until its separate Cloudsmith migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)