### PR TITLE
Release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-06-15
+
 ### Fixed
 
 - **node:** refresh the NodeSource repository signing key; the previous copy used a

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 3.0.0
+version: 4.0.0
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
Cuts **v4.0.0** (MAJOR — breaking changes). Bumps `galaxy.yml` to `4.0.0` and promotes `[Unreleased]` to `## [4.0.0] - 2026-06-15`.

Highlights since v3.0.0:
- **Added:** `apt_keys` role (centralised signing keys, installed before any apt update) and a scheduled `key-check` monitor (expiry + live repo verification on bookworm & trixie, Slack alerts).
- **Fixed:** refreshed node & new_relic signing keys for trixie.
- **Changed (BREAKING):** keyrings moved to `/etc/apt/keyrings/`, managed centrally by `apt_keys`; rabbitmq migrated to `deb1.rabbitmq.com`.
- **Removed (BREAKING):** per-role `add-key` tasks; nginx `fix-key` workaround.

After merge, `main` is tagged `v4.0.0` and `release.yml` publishes the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)