### PR TITLE
fix: legacy apt source cleanup never matched repo URL (Signed-By conflict)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+### Fixed
+
+- **mysql, rabbitmq, node, new_relic, nginx, pgsql, pgsql_client, yarn, php_repo_sury,
+  base:** legacy apt-source cleanup now removes stale `.list` files whose repository URL
+  is not at the start of the line. The `find`/`contains` filter defaulted to anchored
+  matching (`re.match`), so source files left by pre-key-centralization installs were
+  never deleted, producing `Conflicting values set for option Signed-By` errors during
+  `apt-get update`. Added `read_whole_file: true` to the legacy-source `find` tasks.
+
 ## [4.0.0] - 2026-06-15
 
 ### Fixed

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -46,6 +46,7 @@
         paths: /etc/apt/sources.list.d
         patterns: "*.list"
         contains: 'deb\.debian\.org/debian.*backports'
+        read_whole_file: true
       register: base_legacy_backports
 
     - name: Remove legacy backports list file

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -20,6 +20,7 @@
     paths: /etc/apt/sources.list.d
     patterns: "*.list"
     contains: 'repo\.mysql\.com'
+    read_whole_file: true
   register: mysql_legacy_list
 
 - name: Remove legacy MySQL list file

--- a/roles/new_relic/tasks/main.yml
+++ b/roles/new_relic/tasks/main.yml
@@ -20,6 +20,7 @@
     paths: /etc/apt/sources.list.d
     patterns: "*.list"
     contains: 'apt\.newrelic\.com'
+    read_whole_file: true
   register: new_relic_legacy_list
 
 - name: Remove legacy New Relic list file

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -20,6 +20,7 @@
     paths: /etc/apt/sources.list.d
     patterns: "*.list"
     contains: 'nginx\.org/packages'
+    read_whole_file: true
   register: nginx_legacy_list
 
 - name: Remove legacy Nginx list file

--- a/roles/node/tasks/remove-node-repo.yml
+++ b/roles/node/tasks/remove-node-repo.yml
@@ -6,6 +6,7 @@
       - "*.list"
       - "*.sources"
     contains: 'deb\.nodesource\.com/node_{{ version }}\.x'
+    read_whole_file: true
   register: node_remove_list
 
 - name: "Remove Node repo: {{ version }}"

--- a/roles/node/tasks/remove-old-node-repo.yml
+++ b/roles/node/tasks/remove-old-node-repo.yml
@@ -4,6 +4,7 @@
     paths: /etc/apt/sources.list.d
     patterns: "*.list"
     contains: 'deb\.nodesource\.com'
+    read_whole_file: true
   register: node_legacy_list
 
 - name: Remove legacy Node list files

--- a/roles/pgsql/tasks/main.yml
+++ b/roles/pgsql/tasks/main.yml
@@ -21,6 +21,7 @@
     paths: /etc/apt/sources.list.d
     patterns: "*.list"
     contains: 'apt\.postgresql\.org'
+    read_whole_file: true
   register: postgres_legacy_list
 
 - name: Remove legacy PostgreSQL list file

--- a/roles/pgsql_client/tasks/main.yml
+++ b/roles/pgsql_client/tasks/main.yml
@@ -21,6 +21,7 @@
     paths: /etc/apt/sources.list.d
     patterns: "*.list"
     contains: 'apt\.postgresql\.org'
+    read_whole_file: true
   register: postgres_legacy_list
 
 - name: Remove legacy PostgreSQL list file

--- a/roles/php_repo_sury/tasks/main.yml
+++ b/roles/php_repo_sury/tasks/main.yml
@@ -20,6 +20,7 @@
     paths: /etc/apt/sources.list.d
     patterns: "*.list"
     contains: 'packages\.sury\.org'
+    read_whole_file: true
   register: php_repo_sury_legacy_list
 
 - name: Remove legacy PHP list file

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -45,6 +45,7 @@
     paths: /etc/apt/sources.list.d
     patterns: "*.list"
     contains: 'rabbitmq\.com'
+    read_whole_file: true
   register: rabbitmq_legacy_list
 
 - name: Remove legacy RabbitMQ list file

--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -20,6 +20,7 @@
     paths: /etc/apt/sources.list.d
     patterns: "*.list"
     contains: 'dl\.yarnpkg\.com'
+    read_whole_file: true
   register: yarn_legacy_list
 
 - name: Remove legacy Yarn list file


### PR DESCRIPTION
## Summary

Legacy apt-source cleanup tasks use `ansible.builtin.find` with a `contains` filter to
locate stale `.list` files left from before apt-key centralization. With the default
`read_whole_file: false`, `contains` matches each line with `re.match` (anchored at line
start), so a domain pattern like `repo\.mysql\.com` never matches a
`deb [...] https://repo.mysql.com/...` line. The stale file was never removed, leaving a
conflicting `Signed-By` definition that broke `apt-get update`:

```
E:Conflicting values set for option Signed-By regarding source
https://repo.mysql.com/apt/debian/ bookworm:
/etc/apt/keyrings/mysql-repo.gpg != /usr/share/keyrings/mysql-repo.gpg
```

Confirmed on a host provisioned before centralization: the role's `Remove legacy MySQL
list file` task was skipping because `find` matched nothing.

## Fix

Add `read_whole_file: true` (whole-file `re.search`) to every legacy-source `find` task
across `mysql`, `rabbitmq`, `node` (×2), `new_relic`, `nginx`, `pgsql`, `pgsql_client`,
`yarn`, `php_repo_sury`, and `base`. Patterns unchanged.

## Versioning

Non-breaking bug fix → **PATCH** (recommend `v4.0.1`).

## Test

`make lint` → 0 failure(s), 0 warning(s).
