### PR TITLE
Release v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [4.0.1] - 2026-06-24
+
 ### Fixed
 
 - **mysql, rabbitmq, node, new_relic, nginx, pgsql, pgsql_client, yarn, php_repo_sury,

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 4.0.0
+version: 4.0.1
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
Patch release: legacy apt-source cleanup now matches repository URLs anywhere in the line (fixes `Signed-By` conflicts on pre-key-centralization hosts). See CHANGELOG `## [4.0.1]`.

Bumps `galaxy.yml` to 4.0.1 and promotes `[Unreleased]`. After merge: tag `v4.0.1` on main to trigger the release workflow.