### PR TITLE
fix: refresh apt cache after adding third-party repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+### Fixed
+
+- **pgsql, pgsql_client, nginx, mysql, redis, rabbitmq, node, yarn, new_relic,
+  php_repo_sury, base:** refresh the apt cache immediately after adding a third-party
+  repository so freshly added repos are visible to the install step. The
+  `deb822_repository` module does not update the cache, and the following install task's
+  `cache_valid_time` could treat the cache refreshed seconds earlier (before the repo
+  existed) as fresh and skip the update, producing errors such as
+  `No package matching 'postgresql-15' is available` on first provision. The new refresh
+  runs only when the repository file changes.
+
 ## [4.0.1] - 2026-06-24
 
 ### Fixed

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -40,6 +40,12 @@
         suites: "{{ ansible_facts['distribution_release'] }}-backports"
         components: main
         state: present
+      register: base_backports_repo
+
+    - name: Update apt cache after adding repository # noqa: no-handler
+      ansible.builtin.apt:
+        update_cache: true
+      when: base_backports_repo is changed
 
     - name: Find legacy backports list file
       ansible.builtin.find:

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -14,6 +14,12 @@
     suites: "{{ ansible_facts['distribution_release'] }}"
     components: "mysql-{{ mysql_version }}"
     signed_by: /etc/apt/keyrings/mysql-repo.gpg
+  register: mysql_repo
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: mysql_repo is changed
 
 - name: Find legacy MySQL list file
   ansible.builtin.find:

--- a/roles/new_relic/tasks/main.yml
+++ b/roles/new_relic/tasks/main.yml
@@ -14,6 +14,12 @@
     suites: newrelic
     components: non-free
     signed_by: /etc/apt/keyrings/newrelic-repo.gpg
+  register: new_relic_repo
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: new_relic_repo is changed
 
 - name: Find legacy New Relic list file
   ansible.builtin.find:

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -14,6 +14,12 @@
     suites: "{{ ansible_facts['distribution_release'] }}"
     components: nginx
     signed_by: /etc/apt/keyrings/nginx-archive-keyring.gpg
+  register: nginx_repo
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: nginx_repo is changed
 
 - name: Find legacy Nginx list file
   ansible.builtin.find:

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -19,6 +19,11 @@
     signed_by: /etc/apt/keyrings/nodesource.gpg
   register: node_repo
 
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: node_repo is changed
+
 - name: Install Node
   ansible.builtin.apt:
     pkg: nodejs

--- a/roles/pgsql/tasks/main.yml
+++ b/roles/pgsql/tasks/main.yml
@@ -15,6 +15,12 @@
     components: main
     signed_by: /etc/apt/keyrings/postgresql.gpg
     state: present
+  register: postgres_repo
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: postgres_repo is changed
 
 - name: Find legacy PostgreSQL list file
   ansible.builtin.find:

--- a/roles/pgsql_client/tasks/main.yml
+++ b/roles/pgsql_client/tasks/main.yml
@@ -15,6 +15,12 @@
     components: main
     signed_by: /etc/apt/keyrings/postgresql.gpg
     state: present
+  register: postgres_repo
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: postgres_repo is changed
 
 - name: Find legacy PostgreSQL list file
   ansible.builtin.find:

--- a/roles/php_repo_sury/tasks/main.yml
+++ b/roles/php_repo_sury/tasks/main.yml
@@ -14,6 +14,12 @@
     suites: "{{ ansible_facts['distribution_release'] }}"
     components: main
     signed_by: /etc/apt/keyrings/php-sury-repo.gpg
+  register: php_repo_sury_repo
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: php_repo_sury_repo is changed
 
 - name: Find legacy PHP list file
   ansible.builtin.find:

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -14,6 +14,7 @@
     suites: "{{ ansible_facts['distribution_release'] }}"
     components: main
     signed_by: /etc/apt/keyrings/rabbitmq.gpg
+  register: rabbitmq_erlang_repo
 
 - name: Add RabbitMQ server repository
   ansible.builtin.deb822_repository:
@@ -23,6 +24,12 @@
     suites: "{{ ansible_facts['distribution_release'] }}"
     components: main
     signed_by: /etc/apt/keyrings/rabbitmq.gpg
+  register: rabbitmq_server_repo
+
+- name: Update apt cache after adding repositories # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: rabbitmq_erlang_repo is changed or rabbitmq_server_repo is changed
 
 - name: Prefer RabbitMQ upstream Erlang packages
   ansible.builtin.copy:

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -14,6 +14,12 @@
     suites: "{{ ansible_facts['distribution_release'] }}"
     components: main
     signed_by: /etc/apt/keyrings/redis-archive-keyring.gpg
+  register: redis_repo
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: redis_repo is changed
 
 - name: Pin Redis version
   ansible.builtin.template:

--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -14,6 +14,12 @@
     suites: stable
     components: main
     signed_by: /etc/apt/keyrings/yarn-repo.gpg
+  register: yarn_repo
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: yarn_repo is changed
 
 - name: Find legacy Yarn list file
   ansible.builtin.find:


### PR DESCRIPTION
## Problem

Provisioning a new server failed in the `pgsql` role with:

```
No package matching 'postgresql-15' is available
roles/pgsql/tasks/main.yml:35  (Install PostgreSQL packages)
```

The root cause is **systemic across every repo-adding role**, not pgsql-specific. Each follows the same shape:

1. *Install deb822 dependency* — `ansible.builtin.apt` with `update_cache: true` + `cache_valid_time: 3600` → refreshes the cache and stamps it **now**.
2. *Add … repository* — `ansible.builtin.deb822_repository` writes a new `.sources` file but does **not** touch the cache (the module has **no** `update_cache` option — only the legacy `apt_repository` had one).
3. *Install …* — `update_cache: true` + `cache_valid_time: 3600` → **skipped**, because step 1 stamped the cache seconds earlier, *before* the repo existed. The new repo's package list is never fetched → the package is invisible.

## Fix

Register each `deb822_repository` and run an `apt update` immediately after, gated on `when: <repo> is changed` (idempotent — only refreshes when the repo file actually changes; carries `# noqa: no-handler` since a handler would run at end-of-play, too late for the install task).

Covers: **pgsql, pgsql_client, nginx, mysql, redis, rabbitmq** (two repos), **node, yarn, new_relic, php_repo_sury** (had no install step → never refreshed), and **base** (backports block).

## Verification

- `make lint` passes (0 failures, `shared` profile).
- Re-run the failed provision → `Install PostgreSQL packages` succeeds.
- Idempotency: run twice — the new "Update apt cache" tasks report **changed** on first run, **skipped** on second.

Non-breaking (no variables/defaults/task-name contracts changed) → PATCH bump when released.