### PR TITLE
chore: update setup-python and use full version in pin comment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
       - run: pip install -r requirements-dev.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+### Changed
+
+- **meta:** bump `actions/setup-python` to v6.3.0 (was v6.2.0) and pin it with the full
+  `#.#.#` version in the SHA comment for consistency with the other workflow actions.
+
 ### Fixed
 
 - **pgsql, pgsql_client, nginx, mysql, redis, rabbitmq, node, yarn, new_relic,


### PR DESCRIPTION
Audit of all GitHub Actions across the three workflows (`build.yml`, `release.yml`, `key-check.yml`):

| Action | Was | Now | Status |
|---|---|---|---|
| `actions/checkout` | `# v7.0.0` | — | ✅ latest, full version already |
| `softprops/action-gh-release` | `# v3.0.1` | — | ✅ latest, full version already |
| `actions/setup-python` | SHA = v6.2.0, comment `# v6` | SHA = v6.3.0, comment `# v6.3.0` | 🔧 updated |

Only `setup-python` needed changes — it was pinned to the **v6.2.0** SHA (despite the `# v6` comment) while latest is **v6.3.0**, and the comment wasn't the full `#.#.#` form. Bumped to the verified `v6.3.0` commit (`ece7cb0`) and wrote the full version in the comment, matching how the other actions are pinned. All pins remain SHA-pinned with a version comment.