### PR TITLE
Release v4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [4.0.2] - 2026-06-26
+
 ### Changed
 
 - **meta:** bump `actions/setup-python` to v6.3.0 (was v6.2.0) and pin it with the full

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 4.0.1
+version: 4.0.2
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
Cuts **v4.0.2** (PATCH — bug fix + dependency bump, nothing breaking).

Bumps `galaxy.yml` to `4.0.2` and promotes `[Unreleased]` → `## [4.0.2] - 2026-06-26`.

### Changed
- **meta:** bump `actions/setup-python` to v6.3.0 (was v6.2.0) and pin it with the full `#.#.#` version in the SHA comment.

### Fixed
- **pgsql, pgsql_client, nginx, mysql, redis, rabbitmq, node, yarn, new_relic, php_repo_sury, base:** refresh the apt cache immediately after adding a third-party repository so freshly added repos are visible to the install step (e.g. `No package matching 'postgresql-15' is available`).

After merge, tag `main` with `v4.0.2` and push the tag — `release.yml` verifies the tag matches `galaxy.yml`/`CHANGELOG.md` and publishes the GitHub Release.