### PR TITLE
aws_cli: stop leaking per-user secrets in playbook output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+### Fixed
+
+- **aws_cli:** stop leaking per-user AWS credentials in playbook output. The
+  `Per-user config` loop used `with_items`, so Ansible printed each item's full
+  dict — including `access_key_id` and `secret_access_key` — in the `included:`
+  task line. A `loop_control` label now shows only the user name.
+
 ## [4.0.2] - 2026-06-26
 
 ### Changed

--- a/roles/aws_cli/tasks/main.yml
+++ b/roles/aws_cli/tasks/main.yml
@@ -17,3 +17,4 @@
   with_items: "{{ aws_cli_config }}"
   loop_control:
     loop_var: aws_cli_user_config
+    label: "{{ aws_cli_user_config.user }}"


### PR DESCRIPTION
## Summary

The `aws_cli` role's `Per-user config` loop used `with_items`, so Ansible printed each item's full dict — including `access_key_id` and `secret_access_key` — in the `included:` task line of playbook output.

A `loop_control` label now shows only the user name, keeping the credentials out of the logs.

## Changes

- `roles/aws_cli/tasks/main.yml` — add `label: "{{ aws_cli_user_config.user }}"` to the loop control.
- `CHANGELOG.md` — `### Fixed` entry under `[Unreleased]`.