### PR TITLE
Refresh apt cache after legacy source cleanup, not before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ### Fixed
 
+- **pgsql, pgsql_client, nginx, mysql, rabbitmq, yarn, new_relic, php_repo_sury, base:**
+  run the post-repo-add apt cache refresh *after* the legacy `.list` cleanup instead of
+  before it. On hosts still carrying a stale legacy source, the v4.0.2 refresh ran
+  `apt-get update` while the conflicting file was still present, crashing with
+  `Conflicting values set for option Signed-By` before the cleanup could remove it.
 - **aws_cli:** stop leaking per-user AWS credentials in playbook output. The
   `Per-user config` loop used `with_items`, so Ansible printed each item's full
   dict — including `access_key_id` and `secret_access_key` — in the `included:`

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -42,11 +42,6 @@
         state: present
       register: base_backports_repo
 
-    - name: Update apt cache after adding repository # noqa: no-handler
-      ansible.builtin.apt:
-        update_cache: true
-      when: base_backports_repo is changed
-
     - name: Find legacy backports list file
       ansible.builtin.find:
         paths: /etc/apt/sources.list.d
@@ -62,6 +57,11 @@
       loop: "{{ base_legacy_backports.files }}"
       loop_control:
         label: "{{ item.path }}"
+
+    - name: Update apt cache after adding repository # noqa: no-handler
+      ansible.builtin.apt:
+        update_cache: true
+      when: base_backports_repo is changed
 
 - name: Install system packages
   ansible.builtin.apt:

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -16,11 +16,6 @@
     signed_by: /etc/apt/keyrings/mysql-repo.gpg
   register: mysql_repo
 
-- name: Update apt cache after adding repository # noqa: no-handler
-  ansible.builtin.apt:
-    update_cache: true
-  when: mysql_repo is changed
-
 - name: Find legacy MySQL list file
   ansible.builtin.find:
     paths: /etc/apt/sources.list.d
@@ -36,6 +31,11 @@
   loop: "{{ mysql_legacy_list.files }}"
   loop_control:
     label: "{{ item.path }}"
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: mysql_repo is changed
 
 - name: Check if MySQL server installed
   ansible.builtin.shell: dpkg-query -W -f='${db:Status-Abbrev}' mysql-server || true

--- a/roles/new_relic/tasks/main.yml
+++ b/roles/new_relic/tasks/main.yml
@@ -16,11 +16,6 @@
     signed_by: /etc/apt/keyrings/newrelic-repo.gpg
   register: new_relic_repo
 
-- name: Update apt cache after adding repository # noqa: no-handler
-  ansible.builtin.apt:
-    update_cache: true
-  when: new_relic_repo is changed
-
 - name: Find legacy New Relic list file
   ansible.builtin.find:
     paths: /etc/apt/sources.list.d
@@ -36,6 +31,11 @@
   loop: "{{ new_relic_legacy_list.files }}"
   loop_control:
     label: "{{ item.path }}"
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: new_relic_repo is changed
 
 - name: Install New Relic
   ansible.builtin.apt:

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -16,11 +16,6 @@
     signed_by: /etc/apt/keyrings/nginx-archive-keyring.gpg
   register: nginx_repo
 
-- name: Update apt cache after adding repository # noqa: no-handler
-  ansible.builtin.apt:
-    update_cache: true
-  when: nginx_repo is changed
-
 - name: Find legacy Nginx list file
   ansible.builtin.find:
     paths: /etc/apt/sources.list.d
@@ -36,6 +31,11 @@
   loop: "{{ nginx_legacy_list.files }}"
   loop_control:
     label: "{{ item.path }}"
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: nginx_repo is changed
 
 # passlib for basic auth
 - name: Install Nginx

--- a/roles/pgsql/tasks/main.yml
+++ b/roles/pgsql/tasks/main.yml
@@ -17,11 +17,6 @@
     state: present
   register: postgres_repo
 
-- name: Update apt cache after adding repository # noqa: no-handler
-  ansible.builtin.apt:
-    update_cache: true
-  when: postgres_repo is changed
-
 - name: Find legacy PostgreSQL list file
   ansible.builtin.find:
     paths: /etc/apt/sources.list.d
@@ -37,6 +32,11 @@
   loop: "{{ postgres_legacy_list.files }}"
   loop_control:
     label: "{{ item.path }}"
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: postgres_repo is changed
 
 - name: Install PostgreSQL packages
   ansible.builtin.apt:

--- a/roles/pgsql_client/tasks/main.yml
+++ b/roles/pgsql_client/tasks/main.yml
@@ -17,11 +17,6 @@
     state: present
   register: postgres_repo
 
-- name: Update apt cache after adding repository # noqa: no-handler
-  ansible.builtin.apt:
-    update_cache: true
-  when: postgres_repo is changed
-
 - name: Find legacy PostgreSQL list file
   ansible.builtin.find:
     paths: /etc/apt/sources.list.d
@@ -37,6 +32,11 @@
   loop: "{{ postgres_legacy_list.files }}"
   loop_control:
     label: "{{ item.path }}"
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: postgres_repo is changed
 
 - name: Install PostgreSQL client packages
   ansible.builtin.apt:

--- a/roles/php_repo_sury/tasks/main.yml
+++ b/roles/php_repo_sury/tasks/main.yml
@@ -16,11 +16,6 @@
     signed_by: /etc/apt/keyrings/php-sury-repo.gpg
   register: php_repo_sury_repo
 
-- name: Update apt cache after adding repository # noqa: no-handler
-  ansible.builtin.apt:
-    update_cache: true
-  when: php_repo_sury_repo is changed
-
 - name: Find legacy PHP list file
   ansible.builtin.find:
     paths: /etc/apt/sources.list.d
@@ -36,6 +31,11 @@
   loop: "{{ php_repo_sury_legacy_list.files }}"
   loop_control:
     label: "{{ item.path }}"
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: php_repo_sury_repo is changed
 
 - name: Install xdebug control scripts
   ansible.builtin.template:

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -26,11 +26,6 @@
     signed_by: /etc/apt/keyrings/rabbitmq.gpg
   register: rabbitmq_server_repo
 
-- name: Update apt cache after adding repositories # noqa: no-handler
-  ansible.builtin.apt:
-    update_cache: true
-  when: rabbitmq_erlang_repo is changed or rabbitmq_server_repo is changed
-
 - name: Prefer RabbitMQ upstream Erlang packages
   ansible.builtin.copy:
     dest: /etc/apt/preferences.d/rabbitmq-erlang.pref
@@ -62,6 +57,11 @@
   loop: "{{ rabbitmq_legacy_list.files }}"
   loop_control:
     label: "{{ item.path }}"
+
+- name: Update apt cache after adding repositories # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: rabbitmq_erlang_repo is changed or rabbitmq_server_repo is changed
 
 - name: Install RabbitMQ
   ansible.builtin.apt:

--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -16,11 +16,6 @@
     signed_by: /etc/apt/keyrings/yarn-repo.gpg
   register: yarn_repo
 
-- name: Update apt cache after adding repository # noqa: no-handler
-  ansible.builtin.apt:
-    update_cache: true
-  when: yarn_repo is changed
-
 - name: Find legacy Yarn list file
   ansible.builtin.find:
     paths: /etc/apt/sources.list.d
@@ -36,6 +31,11 @@
   loop: "{{ yarn_legacy_list.files }}"
   loop_control:
     label: "{{ item.path }}"
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: yarn_repo is changed
 
 - name: Install Yarn
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary

v4.0.2 added a post-repo-add apt cache refresh to every repo-adding role, but placed it **before** the `Remove legacy … list file` cleanup. On a host still carrying a stale legacy `.list` source, that `apt-get update` crashes with `Conflicting values set for option Signed-By` — the exact failure v4.0.1's cleanup was written to prevent — before the cleanup task can delete the offending file.

This moves the refresh to run **after** the legacy-source removal (and before the first install that depends on it) in every affected role.

## Changes

- **pgsql, pgsql_client, nginx, mysql, yarn, new_relic, php_repo_sury** — refresh moved after `Remove legacy … list file`
- **rabbitmq** — refresh moved after `Remove legacy RabbitMQ list file` (past both the superseded `.sources` and legacy `.list` removals)
- **base** — refresh moved after `Remove legacy backports list file`, still inside the `base_use_backports` block

No change to **node** (legacy cleanup imported before the add) or **redis** (no legacy `.list` cleanup).

Only task ordering changes — no variables/defaults/task-name contracts change.

## Release impact

Non-breaking → **PATCH** bump.

## Verification

- `make lint` passes (0 failures, `shared` profile).