### PR TITLE
Release v4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [4.0.3] - 2026-07-03
+
 ### Fixed
 
 - **pgsql, pgsql_client, nginx, mysql, rabbitmq, yarn, new_relic, php_repo_sury, base:**

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 4.0.2
+version: 4.0.3
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
Release **v4.0.3** (PATCH).

Promotes `[Unreleased]` → `## [4.0.3]` and bumps `galaxy.yml` to `4.0.3`.

### Fixed
- **pgsql, pgsql_client, nginx, mysql, rabbitmq, yarn, new_relic, php_repo_sury, base:** run the post-repo-add apt cache refresh *after* the legacy `.list` cleanup instead of before it (#110).
- **aws_cli:** stop leaking per-user AWS credentials in playbook output.