### PR TITLE
mysql: fix 5.x-upgrade auth migration, redundant root users, and InnoDB redo log deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,19 @@ flagged with **BREAKING** and require a MAJOR version bump.
   of them, failing the role with `SELECT command denied to user 'root'@'localhost'`.
   `root@localhost` is the canonical superuser.
 
-### Removed
+### Changed
 
-- **mysql:** **BREAKING** replace `mysql_innodb_log_file_size` and
-  `mysql_innodb_log_files_in_group` with `mysql_innodb_redo_log_capacity` (default
-  `256M`, the same effective capacity) — the old parameters are deprecated since MySQL
-  8.0.30. If you overrode them, set `capacity = size × group`. Also drop the obsolete
-  `ib_logfile` deletion on fresh installs.
+- **mysql:** the tuning config now sets `innodb_redo_log_capacity` (new variable
+  `mysql_innodb_redo_log_capacity`, default `256M` — the same effective capacity as the
+  old defaults) instead of the InnoDB parameters deprecated since MySQL 8.0.30. Also
+  drop the obsolete `ib_logfile` deletion on fresh installs.
+
+### Deprecated
+
+- **mysql:** `mysql_innodb_log_file_size` and `mysql_innodb_log_files_in_group` — still
+  honoured if set (redo capacity is derived as `size × group`, overriding
+  `mysql_innodb_redo_log_capacity`), but they will be removed in a future major
+  release; switch to `mysql_innodb_redo_log_capacity`.
 
 ## [4.0.3] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+### Added
+
+- **mysql:** `mysql_login_unix_socket` variable (default `/var/run/mysqld/mysqld.sock`);
+  all role logins now connect via the unix socket so they always run as
+  `root@localhost`.
+
+### Fixed
+
+- **mysql:** temporarily enable `mysql_native_password` (drop-in config + restart) when
+  root still authenticates with it after a 5.x upgrade, migrate managed accounts to
+  `caching_sha2_password`, then remove the drop-in and restart. Previously the role
+  failed outright on MySQL 8.4, where the plugin is disabled by default. Accounts not
+  listed in `mysql_users` remain on the disabled plugin once the drop-in is removed.
+- **mysql:** remove legacy `root@'127.0.0.1'` and `root@'::1'` rows left over from 5.x
+  installs; their grants break after upgrades and the default TCP login could match one
+  of them, failing the role with `SELECT command denied to user 'root'@'localhost'`.
+  `root@localhost` is the canonical superuser.
+
+### Removed
+
+- **mysql:** **BREAKING** replace `mysql_innodb_log_file_size` and
+  `mysql_innodb_log_files_in_group` with `mysql_innodb_redo_log_capacity` (default
+  `256M`, the same effective capacity) — the old parameters are deprecated since MySQL
+  8.0.30. If you overrode them, set `capacity = size × group`. Also drop the obsolete
+  `ib_logfile` deletion on fresh installs.
+
 ## [4.0.3] - 2026-07-03
 
 ### Fixed

--- a/roles/mysql/README.md
+++ b/roles/mysql/README.md
@@ -10,8 +10,7 @@ Installs and configures MySQL server.
 | `mysql_users` | `[]` | Users to create |
 | `mysql_databases` | `[]` | Databases to create |
 | `mysql_innodb_buffer_pool_size` | | InnoDB buffer pool size (required, max 0.5 * RAM) |
-| `mysql_innodb_log_file_size` | `128M` | InnoDB log file size (256M if >8GB RAM) |
+| `mysql_innodb_redo_log_capacity` | `256M` | InnoDB redo log capacity (e.g. 1G if >8GB RAM) |
 | `mysql_innodb_flush_log_at_trx_commit` | `1` | Flush log at commit (0 for VM performance) |
-| `mysql_innodb_log_files_in_group` | `2` | Log files in group (4 if >2GB RAM) |
 | `mysql_slow_query_log` | `0` | Enable slow query logging |
 | `mysql_login_unix_socket` | `/var/run/mysqld/mysqld.sock` | Socket used for role logins (always matches `root@localhost`) |

--- a/roles/mysql/README.md
+++ b/roles/mysql/README.md
@@ -14,3 +14,4 @@ Installs and configures MySQL server.
 | `mysql_innodb_flush_log_at_trx_commit` | `1` | Flush log at commit (0 for VM performance) |
 | `mysql_innodb_log_files_in_group` | `2` | Log files in group (4 if >2GB RAM) |
 | `mysql_slow_query_log` | `0` | Enable slow query logging |
+| `mysql_login_unix_socket` | `/var/run/mysqld/mysqld.sock` | Socket used for role logins (always matches `root@localhost`) |

--- a/roles/mysql/README.md
+++ b/roles/mysql/README.md
@@ -14,3 +14,8 @@ Installs and configures MySQL server.
 | `mysql_innodb_flush_log_at_trx_commit` | `1` | Flush log at commit (0 for VM performance) |
 | `mysql_slow_query_log` | `0` | Enable slow query logging |
 | `mysql_login_unix_socket` | `/var/run/mysqld/mysqld.sock` | Socket used for role logins (always matches `root@localhost`) |
+
+The deprecated `mysql_innodb_log_file_size` and `mysql_innodb_log_files_in_group`
+variables are still honoured if set (redo capacity is derived as `size × group`,
+overriding `mysql_innodb_redo_log_capacity`), but they will be removed in a future
+major release.

--- a/roles/mysql/defaults/main.yml
+++ b/roles/mysql/defaults/main.yml
@@ -7,5 +7,6 @@ mysql_innodb_log_file_size: 128M
 mysql_innodb_flush_log_at_trx_commit: 1
 mysql_innodb_log_files_in_group: 2
 mysql_slow_query_log: 0
+mysql_login_unix_socket: /var/run/mysqld/mysqld.sock
 
 mysql_version: 8.4-lts

--- a/roles/mysql/defaults/main.yml
+++ b/roles/mysql/defaults/main.yml
@@ -3,9 +3,8 @@
 mysql_users: []
 # - { name: example, collation: utf8_general_ci, encoding: utf8 }
 mysql_databases: []
-mysql_innodb_log_file_size: 128M
+mysql_innodb_redo_log_capacity: 256M
 mysql_innodb_flush_log_at_trx_commit: 1
-mysql_innodb_log_files_in_group: 2
 mysql_slow_query_log: 0
 mysql_login_unix_socket: /var/run/mysqld/mysqld.sock
 

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -81,6 +81,7 @@
     host_all: true
     login_user: root
     login_password: "{{ mysql_root_password }}"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
     plugin: caching_sha2_password
     plugin_auth_string: "{{ mysql_root_password }}"
     check_implicit_admin: true
@@ -94,6 +95,7 @@
     state: present
     login_user: root
     login_password: "{{ mysql_root_password }}"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
   with_items: "{{ mysql_databases }}"
 
 - name: Create users
@@ -106,6 +108,7 @@
     state: present
     login_user: root
     login_password: "{{ mysql_root_password }}"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
     column_case_sensitive: true
   no_log: false
   loop_control:

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -55,6 +55,15 @@
     state: stopped
   when: mysql_installed.stdout != "ii "
 
+- name: Warn about deprecated InnoDB redo log variables
+  ansible.builtin.debug:
+    msg: >-
+      DEPRECATION WARNING: mysql_innodb_log_file_size and
+      mysql_innodb_log_files_in_group are deprecated and will be removed in a
+      future major release; set mysql_innodb_redo_log_capacity (size * group)
+      instead.
+  when: mysql_innodb_log_file_size is defined or mysql_innodb_log_files_in_group is defined
+
 - name: Configure
   ansible.builtin.template:
     src: tuning.cnf.j2

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -55,11 +55,6 @@
     state: stopped
   when: mysql_installed.stdout != "ii "
 
-- name: Delete InnoDB logs if fresh install # changing logfile size causes restart issue until logs deleted
-  ansible.builtin.shell: rm -f /var/lib/mysql/ib_logfile[01]
-  changed_when: true
-  when: mysql_installed.stdout != "ii "
-
 - name: Configure
   ansible.builtin.template:
     src: tuning.cnf.j2

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -123,6 +123,18 @@
     check_implicit_admin: true
     column_case_sensitive: true
 
+- name: Remove redundant root user for {{ item }}
+  ansible.mysql.mysql_user:
+    name: root
+    host: "{{ item }}"
+    state: absent
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
+  loop:
+    - 127.0.0.1
+    - "::1"
+
 - name: Create databases
   ansible.mysql.mysql_db:
     name: "{{ item.name }}"

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -70,6 +70,47 @@
     state: started
   when: mysql_installed.stdout != "ii "
 
+- name: Check MySQL root login
+  ansible.mysql.mysql_info:
+    filter: version
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
+  register: mysql_root_login
+  failed_when: false
+  changed_when: false
+
+- name: Register whether mysql_native_password is disabled
+  ansible.builtin.set_fact:
+    mysql_native_password_disabled: "{{ \"Plugin 'mysql_native_password' is not loaded\" in mysql_root_login.msg | default('') }}"
+
+- name: Fail if mysql_native_password cannot be enabled
+  ansible.builtin.fail:
+    msg: >-
+      root still authenticates with mysql_native_password but MySQL
+      {{ mysql_version }} has removed the plugin. Install 8.4-lts to
+      migrate authentication first.
+  when:
+    - mysql_native_password_disabled
+    - not (mysql_version | string).startswith('8')
+
+- name: Enable mysql_native_password for auth migration
+  ansible.builtin.copy:
+    content: |
+      [mysqld]
+      mysql_native_password=ON
+    dest: /etc/mysql/conf.d/native_password_migration.cnf
+    owner: root
+    group: root
+    mode: "0644"
+  when: mysql_native_password_disabled
+
+- name: Restart MySQL to load mysql_native_password
+  ansible.builtin.service:
+    name: mysql
+    state: restarted
+  when: mysql_native_password_disabled
+
 - name: Set MySQL root password
   ansible.mysql.mysql_user:
     name: root
@@ -109,3 +150,12 @@
   loop_control:
     label: "{{ item.name }}@{{ item.host | default('localhost') }}"
   with_items: "{{ mysql_users }}"
+
+- name: Remove temporary mysql_native_password config
+  ansible.builtin.file:
+    path: /etc/mysql/conf.d/native_password_migration.cnf
+    state: absent
+  notify: Restart mysql
+
+- name: Restart MySQL if notified
+  ansible.builtin.meta: flush_handlers

--- a/roles/mysql/templates/tuning.cnf.j2
+++ b/roles/mysql/templates/tuning.cnf.j2
@@ -4,6 +4,10 @@
 [mysqld]
 innodb_buffer_pool_size        = {{ mysql_innodb_buffer_pool_size }}
 innodb_flush_log_at_trx_commit = {{ mysql_innodb_flush_log_at_trx_commit }}
+{% if mysql_innodb_log_file_size is defined or mysql_innodb_log_files_in_group is defined %}
+innodb_redo_log_capacity       = {{ (mysql_innodb_log_file_size | default('128M') | ansible.builtin.human_to_bytes) * (mysql_innodb_log_files_in_group | default(2) | int) }}
+{% else %}
 innodb_redo_log_capacity       = {{ mysql_innodb_redo_log_capacity }}
+{% endif %}
 
 slow_query_log                 = {{ mysql_slow_query_log }}

--- a/roles/mysql/templates/tuning.cnf.j2
+++ b/roles/mysql/templates/tuning.cnf.j2
@@ -4,7 +4,6 @@
 [mysqld]
 innodb_buffer_pool_size        = {{ mysql_innodb_buffer_pool_size }}
 innodb_flush_log_at_trx_commit = {{ mysql_innodb_flush_log_at_trx_commit }}
-innodb_log_files_in_group      = {{ mysql_innodb_log_files_in_group }}
-innodb_log_file_size           = {{ mysql_innodb_log_file_size }}
+innodb_redo_log_capacity       = {{ mysql_innodb_redo_log_capacity }}
 
 slow_query_log                 = {{ mysql_slow_query_log }}


### PR DESCRIPTION
## Summary

Three related fixes for the mysql role, all surfacing on servers upgraded from MySQL 5.x to 8.4:

- **Socket login**: all role logins now connect via the unix socket (new `mysql_login_unix_socket` variable, default `/var/run/mysqld/mysqld.sock`) so they always run as `root@localhost`. Fixes the observed staging failure where the default TCP login matched a broken legacy root row and died with `(1142, "SELECT command denied to user 'root'@'localhost' for table 'user'")`.
- **mysql_native_password migration**: when root still authenticates with `mysql_native_password` (disabled by default in 8.4), the role detects the specific 1524 login error, temporarily enables the plugin via a drop-in + restart, migrates root and managed users to `caching_sha2_password`, then removes the drop-in and restarts. Re-runs self-heal a leftover drop-in; a guard fails fast on 9.x where the plugin is removed and the drop-in would prevent mysqld from starting.
- **Redundant root rows**: removes legacy `root@'127.0.0.1'` and `root@'::1'` rows; `root@localhost` is the canonical superuser.
- **InnoDB redo log**: the tuning config now emits `innodb_redo_log_capacity` (new `mysql_innodb_redo_log_capacity` variable, default `256M` = old effective capacity) instead of `innodb_log_file_size`/`innodb_log_files_in_group`, deprecated since 8.0.30. The old variables remain honoured (capacity derived as `size × group`) with a runtime deprecation warning, so this is **not** breaking — MINOR bump suffices. Also drops the obsolete fresh-install `ib_logfile` deletion.

## Notes

- Accounts not managed by `mysql_users` that still use `mysql_native_password` remain locked out once the migration drop-in is removed — same end state as before this change.
- The end-of-role `flush_handlers` moves a pending tuning-config restart from end of play to end of role (benign).

## Testing

- `make lint` clean (production profile).
- Template rendering verified in a container for all three variable combinations (new var only, both old vars, one old var) — derived capacities match `size × group` exactly.