### PR TITLE
Enforce exclusive authorized SSH keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ### Changed
 
+- **base:** **BREAKING** — user authorized keys are now exclusive: any key present on
+  the server that is not listed in the user's `authorized_keys` is removed.
 - **mysql:** the tuning config now sets `innodb_redo_log_capacity` (new variable
   `mysql_innodb_redo_log_capacity`, default `256M` — the same effective capacity as the
   old defaults) instead of the InnoDB parameters deprecated since MySQL 8.0.30. Also

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 - **base:** **BREAKING** — user authorized keys are now exclusive: any key present on
   the server that is not listed in the user's `authorized_keys` is removed.
+- **dbcd:** **BREAKING** — server authorized keys are now exclusive: any key on the
+  `dbcd_server_user` account not in `dbcd_server_client_public_key` /
+  `dbcd_server_consumer_public_keys` is removed.
 - **mysql:** the tuning config now sets `innodb_redo_log_capacity` (new variable
   `mysql_innodb_redo_log_capacity`, default `256M` — the same effective capacity as the
   old defaults) instead of the InnoDB parameters deprecated since MySQL 8.0.30. Also

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -116,13 +116,12 @@
 
 - name: Assign authorized keys
   ansible.posix.authorized_key:
-    user: "{{ item.0.name }}"
-    key: "{{ lookup('file', item.1) }}"
-  with_subelements:
-    - "{{ default_users + users }}"
-    - authorized_keys
+    user: "{{ item.name }}"
+    key: "{% for key in item.authorized_keys %}{{ lookup('file', key) }}\n{% endfor %}"
+    exclusive: true
+  with_items: "{{ default_users + users }}"
   loop_control:
-    label: "{{ item.0.name }} - {{ item.1 }}"
+    label: "{{ item.name }}"
 
 - name: Install openssh from backports
   ansible.builtin.apt:

--- a/roles/dbcd/tasks/server.yml
+++ b/roles/dbcd/tasks/server.yml
@@ -8,18 +8,18 @@
     groups: ssh-users
     shell: /bin/dash
 
-- name: "Assign client (write-only) authorized key"
+- name: "Assign authorized keys"
+  vars:
+    dbcd_server_write_keys:
+      - 'command="rrsync -wo {{ dbcd_data_dir }}" {{ dbcd_server_client_public_key }}'
+    dbcd_server_read_keys: >-
+      {{ dbcd_server_consumer_public_keys
+         | map('ansible.builtin.regex_replace', '^', 'command="rrsync -ro ' ~ dbcd_data_dir ~ '" ')
+         | list }}
   ansible.posix.authorized_key:
     user: "{{ dbcd_server_user }}"
-    key: "{{ dbcd_server_client_public_key }}"
-    key_options: 'command="rrsync -wo {{ dbcd_data_dir }}"'
-
-- name: "Assign consumer (read-only) authorized keys"
-  ansible.posix.authorized_key:
-    user: "{{ dbcd_server_user }}"
-    key: "{{ item }}"
-    key_options: 'command="rrsync -ro {{ dbcd_data_dir }}"'
-  with_items: "{{ dbcd_server_consumer_public_keys }}"
+    key: "{{ (dbcd_server_write_keys + dbcd_server_read_keys) | join('\n') }}"
+    exclusive: true
 
 - name: "Create directory"
   ansible.builtin.file:


### PR DESCRIPTION
## Summary

Anywhere the collection manages authorized SSH keys, only the passed set is now present — any other key on the account (removed from inventory or added by hand) is removed.

- **base:** replaced the per-key `with_subelements` loop with one `authorized_key` call per user, all key file contents newline-joined, `exclusive: true`. (`exclusive` in a per-key loop would keep only the last key.)
- **dbcd:** merged the write-only and read-only key tasks (same user) into a single exclusive call, embedding the per-key `rrsync -wo`/`-ro` forced commands in each key line instead of `key_options`.

**BREAKING** — recommend a MAJOR bump: keys not declared in inventory are removed, and a user with `authorized_keys: []` now has all keys removed rather than being skipped.

## Testing

- Exercised both constructs against the real `ansible.posix.authorized_key` module with scratch `path` files: stale keys removed, declared keys present with correct rrsync options, empty list wipes cleanly, second run idempotent.
- `make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)