### PR TITLE
Release v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-07-13
+
 ### Added
 
 - **mysql:** `mysql_login_unix_socket` variable (default `/var/run/mysqld/mysqld.sock`);

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 4.0.3
+version: 5.0.0
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
Cut v5.0.0: MAJOR bump for the BREAKING exclusive authorized-keys change in **base** and **dbcd** (#113); also includes the mysql 5.x-upgrade fixes (#112). Bumps `galaxy.yml` and promotes `[Unreleased]` to `## [5.0.0] - 2026-07-13`.

After merge, `main` will be tagged `v5.0.0` to publish the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)