### PR TITLE
mysql: probe root auth plugin with a dummy password so no_log censoring cannot defeat detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+### Fixed
+
+- **mysql:** probe the root auth plugin with a fixed dummy password (the 1524 plugin
+  error precedes password verification) so Ansible's `no_log` censoring can never
+  rewrite the error message. Previously, when the real root password value appeared in
+  the message text, the plugin name was masked and detection never fired, failing the
+  role on the very error it was meant to handle.
+
 ## [5.0.0] - 2026-07-13
 
 ### Added

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -79,11 +79,14 @@
     state: started
   when: mysql_installed.stdout != "ii "
 
-- name: Check MySQL root login
+# The dummy password is deliberate: the 1524 plugin error precedes password
+# verification, and a fixed non-secret value can never be masked out of the
+# registered error message by no_log censoring (unlike the real password).
+- name: Check MySQL root auth plugin
   ansible.mysql.mysql_info:
     filter: version
     login_user: root
-    login_password: "{{ mysql_root_password }}"
+    login_password: plugin-probe
     login_unix_socket: "{{ mysql_login_unix_socket }}"
   register: mysql_root_login
   failed_when: false


### PR DESCRIPTION
## Summary

Follow-up to #112. On staging, the `mysql_native_password` detection never fired: Ansible masks every occurrence of the `login_password` value in registered module results, and the root password value appeared in the error text, censoring the plugin name (`Plugin 'mysql_native_********' is not loaded`) so the exact-substring match failed — and the role died on the very 1524 error it was built to handle.

## Fix

Probe with a fixed dummy password (`plugin-probe`) instead of the real credential. The 1524 plugin error precedes password verification, so the probe still detects the disabled plugin — but since the censored value can never appear in MySQL's message text, the registered message is never rewritten and the exact, fully-specific match on `Plugin 'mysql_native_password' is not loaded` is reliable.

Compared with loosening the match to a regex, this keeps detection specific: a *different* missing auth plugin does not match, so the role fails loudly at `Set MySQL root password` with the genuine error rather than pointlessly enabling `mysql_native_password`. On healthy systems the probe just fails with 1045 access denied (tolerated via `failed_when: false`) — it was only ever a plugin sniff.

## Testing

- `make lint` clean (production profile).