### PR TITLE
Add Molecule testing infrastructure with mysql and git pilots

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,3 +3,6 @@ profile: shared
 skip_list:
   - experimental
   - var-naming[no-role-prefix]
+kinds:
+  # Shared molecule scenario values, not playbooks (see docs/testing.md)
+  - vars: "**/molecule/*/vars.yml"

--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -1,0 +1,55 @@
+---
+# Base config for every molecule scenario in this collection. Per-role
+# molecule.yml files override selectively: dicts deep-merge, lists replace
+# (so a role restricted to one distro redefines `platforms` entirely and
+# must also be listed in .config/molecule/platforms.yml for CI).
+# The collection is resolved via the symlink into ~/.ansible/collections made
+# by `make test` / CI, so molecule must not self-install it (prerun) or pull
+# galaxy deps per scenario (dependency).
+prerun: false
+dependency:
+  name: galaxy
+  enabled: false
+driver:
+  name: docker
+platforms:
+  - name: bookworm
+    image: ${MOLECULE_IMAGE_REPO:-ghcr.io/tborealis/ansible-roles}/molecule-debian:bookworm
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    cgroupns_mode: host
+    privileged: false
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+  - name: trixie
+    image: ${MOLECULE_IMAGE_REPO:-ghcr.io/tborealis/ansible-roles}/molecule-debian:trixie
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    cgroupns_mode: host
+    privileged: false
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: /usr/bin/python3
+      callbacks_enabled: ansible.posix.profile_tasks
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/.config/molecule/platforms.yml
+++ b/.config/molecule/platforms.yml
@@ -1,0 +1,5 @@
+---
+# Roles restricted to a subset of releases. Consumed by
+# scripts/molecule_matrix.py when generating the CI matrix. The role's own
+# molecule.yml must override `platforms:` to match.
+rabbitmq: [bookworm] # upstream signing key rejected by trixie's apt (SHA1 binding)

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,0 +1,106 @@
+name: molecule
+
+on:
+  pull_request:
+    paths:
+      - roles/**
+      - docker/**
+      - .config/molecule/**
+      - requirements.yml
+      - requirements-dev.txt
+      - scripts/molecule_matrix.py
+      - .github/workflows/molecule.yml
+  schedule:
+    - cron: "0 5 * * 1" # Mondays 05:00 UTC (images rebuilt Sundays)
+  workflow_dispatch:
+    inputs:
+      roles:
+        description: Space-separated role names (empty = all)
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: molecule-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+      any: ${{ steps.gen.outputs.any }}
+      build_image: ${{ steps.gen.outputs.build_image }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Generate matrix
+        id: gen
+        run: |
+          pip install -q pyyaml
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD > changed.txt
+            python3 scripts/molecule_matrix.py --changed changed.txt
+          else
+            python3 scripts/molecule_matrix.py --all --roles "${{ inputs.roles }}"
+          fi
+
+  test:
+    needs: detect
+    if: needs.detect.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
+    name: ${{ matrix.role }} (${{ matrix.distro }})
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.x"
+
+      - run: pip install -r requirements-dev.txt
+
+      - run: ansible-galaxy install -r requirements.yml
+
+      - name: Link collection into collections path
+        run: |
+          mkdir -p ~/.ansible/collections/ansible_collections/tborealis
+          ln -sfn "$PWD" ~/.ansible/collections/ansible_collections/tborealis/roles
+
+      - name: Build test image from this branch's Dockerfile
+        if: needs.detect.outputs.build_image == 'true'
+        run: |
+          docker build --build-arg RELEASE="${{ matrix.distro }}" \
+            -t "ghcr.io/${{ github.repository }}/molecule-debian:${{ matrix.distro }}" \
+            docker/molecule-debian
+
+      - name: Molecule test
+        working-directory: roles/${{ matrix.role }}
+        env:
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"
+        run: molecule test --platform-name "${{ matrix.distro }}"
+
+  notify:
+    needs: [detect, test]
+    if: ${{ always() && github.event_name != 'pull_request' && needs.detect.outputs.any == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        if: ${{ contains(needs.test.result, 'failure') }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::warning::molecule failures but SLACK_WEBHOOK_URL is not set"; exit 0
+          fi
+          text="molecule: full-matrix run FAILED: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          payload=$(python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1]}))' "$text")
+          curl -fsS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -1,0 +1,34 @@
+name: test-images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docker/**
+      - .github/workflows/test-images.yml
+  schedule:
+    - cron: "0 5 * * 0" # Sundays 05:00 UTC, ahead of Monday's full molecule run
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release: [bookworm, trixie]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and push (${{ matrix.release }})
+        run: |
+          img="ghcr.io/${{ github.repository }}/molecule-debian:${{ matrix.release }}"
+          docker build --pull --build-arg RELEASE="${{ matrix.release }}" -t "$img" docker/molecule-debian
+          docker push "$img"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This is an Ansible Galaxy collection (`tborealis.roles`) containing reusable rol
 ## Commands
 
 - **Lint**: `make lint` (runs ansible-lint in a Docker container with the version pinned in `requirements-dev.txt`)
-- **Test**: No automated tests currently
+- **Test**: `make test ROLE=<name> [DISTRO=bookworm|trixie]` (Molecule with the Docker driver; see [`docs/testing.md`](docs/testing.md))
 
 ## Code Style
 
@@ -63,6 +63,17 @@ without a manifest entry (or vice versa). The live verification runs against eac
 supported Debian release (bookworm and trixie) in its own container, because whether a
 signature is accepted depends on that release's apt. Slack alerts require a
 `SLACK_WEBHOOK_URL` repository secret. Run `make check-keys` to run all checks locally.
+
+## Testing
+
+Every role must ship a Molecule scenario at `roles/<role>/molecule/default/`
+(`molecule.yml`, `converge.yml`, `verify.yml`). Scenarios inherit the shared base
+config at `.config/molecule/config.yml`; verification must be functional (real client
+probes and config-content assertions), not just package/service existence checks.
+Roles that no-op on default variables must be converged with realistic test values.
+A role restricted to a subset of releases overrides `platforms:` in its own
+`molecule.yml` **and** gets an entry in `.config/molecule/platforms.yml`. Scenario
+files must pass `make lint`. Full guide: [`docs/testing.md`](docs/testing.md).
 
 ## Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+### Added
+
+- **meta:** Molecule test infrastructure (systemd-enabled bookworm/trixie test images
+  on GHCR, shared base config, changed-role CI detection with a weekly full matrix,
+  `make test ROLE=<name>`) and pilot scenarios for the `mysql` and `git` roles. See
+  `docs/testing.md`.
+- **mysql:** optional `mysql_root_password_salt` and per-user `salt` (exactly 20
+  characters). Without a salt the caching_sha2_password hash cannot be compared, so
+  the root-password and user tasks reported changed on every run; providing one makes
+  them idempotent.
+
 ### Fixed
 
 - **mysql:** probe the root auth plugin with a fixed dummy password (the 1524 plugin

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint check-keys release
+.PHONY: lint check-keys release test test-images
 
 # Packages each release container needs to run the key checker.
 APT_KEYS_SETUP = apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq gpg ca-certificates python3 python3-yaml
@@ -22,3 +22,21 @@ ifndef VERSION
 	$(error VERSION is required, e.g. make release VERSION=v1.2.3)
 endif
 	./scripts/cut-release.sh $(VERSION)
+
+COLLECTION_LINK = $(HOME)/.ansible/collections/ansible_collections/tborealis/roles
+
+# Molecule tests for one role (see docs/testing.md for setup).
+test:
+ifndef ROLE
+	$(error ROLE is required, e.g. make test ROLE=nginx [DISTRO=bookworm])
+endif
+	mkdir -p $(dir $(COLLECTION_LINK))
+	ln -sfn $(CURDIR) $(COLLECTION_LINK)
+	cd roles/$(ROLE) && molecule test $(if $(DISTRO),--platform-name $(DISTRO),)
+
+# Build the molecule test images locally under the same tags CI pulls.
+test-images:
+	@for r in $(RELEASES); do \
+		docker build --build-arg RELEASE=$$r \
+			-t ghcr.io/tborealis/ansible-roles/molecule-debian:$$r docker/molecule-debian; \
+	done

--- a/docker/molecule-debian/Dockerfile
+++ b/docker/molecule-debian/Dockerfile
@@ -1,0 +1,33 @@
+ARG RELEASE=bookworm
+FROM debian:${RELEASE}
+
+ARG RELEASE
+LABEL org.opencontainers.image.source=https://github.com/tborealis/ansible-roles
+LABEL org.opencontainers.image.description="Molecule test image (Debian ${RELEASE} + systemd)"
+
+ENV container=docker \
+    DEBIAN_FRONTEND=noninteractive
+
+# Baseline a real Debian server would have. Deliberately excludes packages the
+# roles install themselves (e.g. python3-debian) so converge keeps testing them.
+# Apt lists are kept: roles assume a populated cache (base updates it on real
+# hosts) and tasks guarded by cache_valid_time skip the refresh otherwise.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        systemd systemd-sysv dbus sudo \
+        python3 python3-apt \
+        ca-certificates iproute2 procps curl \
+    && apt-get clean \
+    && rm -rf /tmp/* /var/tmp/*
+
+# Trim units that hang, spam, or serve no purpose in a container.
+RUN find /etc/systemd/system /lib/systemd/system \
+        \( -path '*.wants/*getty*' \
+        -o -path '*.wants/*apt-daily*' \
+        -o -path '*.wants/*systemd-udev*' \
+        -o -path '*.wants/*systemd-timesyncd*' \) -delete \
+    && systemctl mask getty.target console-getty.service \
+        systemd-udevd.service systemd-udevd-kernel.socket systemd-udevd-control.socket
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/lib/systemd/systemd"]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,99 @@
+# Testing
+
+Roles are tested with [Molecule](https://ansible.readthedocs.io/projects/molecule/)
+using the Docker driver. Each role's scenario converges the role in a
+systemd-enabled Debian container, checks idempotence (a second converge must
+report no changes), and runs functional verification — real client probes
+(log in to MySQL, curl nginx) and config-content assertions, not just
+"package installed" checks.
+
+Tests run against both supported releases, **bookworm** and **trixie**, using
+images built from [`docker/molecule-debian/Dockerfile`](../docker/molecule-debian/Dockerfile)
+and published to `ghcr.io/tborealis/ansible-roles/molecule-debian:<release>`.
+
+## Local setup
+
+```sh
+python3 -m venv .venv && . .venv/bin/activate
+pip install -r requirements-dev.txt
+ansible-galaxy install -r requirements.yml
+```
+
+Then run a role's tests:
+
+```sh
+make test ROLE=mysql                  # both releases
+make test ROLE=mysql DISTRO=bookworm  # one release
+```
+
+The `test` target symlinks the repo into
+`~/.ansible/collections/ansible_collections/tborealis/roles` so converge
+playbooks resolve `tborealis.roles.<name>` FQCNs (and their `apt_keys` meta
+dependencies) against your working tree.
+
+Images are pulled from GHCR automatically; to build them locally instead (for
+example while changing the Dockerfile) run `make test-images`. Forks can point
+at another registry with `MOLECULE_IMAGE_REPO=ghcr.io/you/your-fork`.
+
+## Debugging a scenario
+
+From `roles/<role>`:
+
+```sh
+molecule converge   # create + converge, leaves the container running
+molecule login      # shell into the container
+molecule verify     # re-run verification against the running container
+molecule destroy
+```
+
+Platform names are fixed (`bookworm`, `trixie`), so two roles cannot run
+molecule at the same time on one machine — the container names clash.
+
+## Writing a scenario
+
+Every role must ship `molecule/default/` containing:
+
+- `molecule.yml` — usually just a comment; it inherits the shared base config
+  at [`.config/molecule/config.yml`](../.config/molecule/config.yml). Dicts
+  deep-merge, **lists replace**, so a role restricted to one release redefines
+  `platforms:` entirely (copy the flags from the base config — see
+  `roles/rabbitmq/molecule/default/molecule.yml`) and must also be added to
+  [`.config/molecule/platforms.yml`](../.config/molecule/platforms.yml) so CI
+  skips the excluded release.
+- `converge.yml` — applies the role by FQCN (`tborealis.roles.<name>`) with
+  `become: true`. Roles that do nothing with default variables must be
+  converged with realistic test values. Values shared between converge and
+  verify (passwords, paths) go in a `vars.yml` loaded with `vars_files`;
+  fixture templates go in `molecule/default/templates/`. Use throwaway
+  secrets with a realistic shape, never real ones.
+- `verify.yml` — functional assertions:
+  - service roles: `service_facts` + assert the service is running, a real
+    client probe (curl, mysql login, `redis-cli ping`), and at least one
+    config-content assertion (`slurp` + `assert` on a value converge set)
+  - tool roles: run the binary and assert on its output (when the binary has
+    a same-named module, tag the task
+    `# noqa: command-instead-of-module` — the point is exercising the binary)
+  - config roles: `stat` for owner/mode, `slurp` + `assert` for content, and
+    native validators where they exist (`visudo -c`, `php-fpm -t`)
+- `prepare.yml` — only for prerequisites outside the role's contract (e.g.
+  installing PHP before testing `php_fpm`). Never prepare things the role
+  should do itself.
+
+Idempotence must pass: prefer fixing a non-idempotent role over tagging tasks
+`molecule-idempotence-notest`. Scenario files are linted like everything else
+(`make lint`): named tasks, FQCN modules, `changed_when: false` on read-only
+commands.
+
+## CI
+
+The `molecule` workflow runs:
+
+- **on PRs** — only roles the PR touches. Changes to shared test
+  infrastructure (`.config/molecule/`, `docker/`, requirements files, the
+  workflow, `scripts/molecule_matrix.py`) run a canary set (`git`, `mysql`);
+  PRs changing the Dockerfile test against an image built from their own
+  branch. Roles without a `molecule/` directory are skipped.
+- **weekly** (Mondays 05:00 UTC, after Sunday's image rebuild) — the full
+  role × release matrix, alerting Slack on failure like `key-check`.
+- **manually** — `workflow_dispatch`, optionally with a space-separated list
+  of roles.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,6 +14,10 @@ build_ignore:
   - .idea
   - .github
   - .gitignore
+  - .ansible
+  - .config
+  - docker
+  - roles/*/molecule
 dependencies:
   ansible.posix: '*'
   ansible.mysql: '*'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,4 @@
+ansible-core==2.21.2
 ansible-lint==26.1.1
+molecule==26.6.0
+molecule-plugins[docker]==26.7.8

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,5 +5,6 @@ collections:
   - name: community.general
   - name: community.postgresql
   - name: community.rabbitmq
+  - name: community.docker # dev/test only: used by the molecule docker driver
 roles:
   - name: ecgalaxy.aws_cli

--- a/roles/git/molecule/default/converge.yml
+++ b/roles/git/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: tborealis.roles.git

--- a/roles/git/molecule/default/molecule.yml
+++ b/roles/git/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/git/molecule/default/prepare.yml
+++ b/roles/git/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+# The role installs git from backports on bookworm and assumes the backports
+# source is already configured (the base role does this on real hosts).
+- name: Prepare
+  hosts: all
+  become: true
+  tasks:
+    - name: Configure backports repo
+      when: ansible_facts['distribution_release'] == 'bookworm'
+      block:
+        - name: Install deb822 dependency
+          ansible.builtin.apt:
+            pkg: python3-debian
+            state: present
+            update_cache: true
+
+        - name: Add backports repo
+          ansible.builtin.deb822_repository:
+            name: debian-backports
+            types: [deb]
+            uris: https://deb.debian.org/debian
+            suites: "{{ ansible_facts['distribution_release'] }}-backports"
+            components: main
+            state: present
+
+        - name: Update apt cache after adding repository
+          ansible.builtin.apt:
+            update_cache: true

--- a/roles/git/molecule/default/verify.yml
+++ b/roles/git/molecule/default/verify.yml
@@ -1,0 +1,28 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+    - name: Run git # noqa: command-instead-of-module (functional check that the binary works)
+      ansible.builtin.command: git --version
+      changed_when: false
+
+    - name: Read global git config
+      ansible.builtin.slurp:
+        src: /etc/gitconfig
+      register: git_verify_gitconfig
+
+    - name: Assert deprecated git protocol is rewritten
+      ansible.builtin.assert:
+        that:
+          - "'insteadOf = git://' in git_verify_gitconfig.content | b64decode"
+
+    - name: Read SSH known hosts
+      ansible.builtin.slurp:
+        src: /etc/ssh/ssh_known_hosts
+      register: git_verify_known_hosts
+
+    - name: Assert GitHub host keys are present
+      ansible.builtin.assert:
+        that:
+          - "'ecdsa-sha2-nistp256' in git_verify_known_hosts.content | b64decode"

--- a/roles/mysql/README.md
+++ b/roles/mysql/README.md
@@ -7,7 +7,8 @@ Installs and configures MySQL server.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `mysql_version` | `8.4-lts` | MySQL version to install |
-| `mysql_users` | `[]` | Users to create |
+| `mysql_users` | `[]` | Users to create (`salt`, exactly 20 characters, makes the password idempotent) |
+| `mysql_root_password_salt` | | Optional 20-character salt; without it the root password task reports changed every run |
 | `mysql_databases` | `[]` | Databases to create |
 | `mysql_innodb_buffer_pool_size` | | InnoDB buffer pool size (required, max 0.5 * RAM) |
 | `mysql_innodb_redo_log_capacity` | `256M` | InnoDB redo log capacity (e.g. 1G if >8GB RAM) |

--- a/roles/mysql/defaults/main.yml
+++ b/roles/mysql/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
-# - { name: example, host: 127.0.0.1, password: secret, priv: *.*:USAGE }
+# - { name: example, host: 127.0.0.1, password: secret, salt: exactly20characters., priv: *.*:USAGE }
+# Without salt (and mysql_root_password_salt for root) the stored
+# caching_sha2_password hash cannot be compared, so the password tasks
+# report changed on every run.
 mysql_users: []
 # - { name: example, collation: utf8_general_ci, encoding: utf8 }
 mysql_databases: []

--- a/roles/mysql/molecule/default/converge.yml
+++ b/roles/mysql/molecule/default/converge.yml
@@ -1,0 +1,18 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    mysql_innodb_buffer_pool_size: 128M
+    mysql_databases:
+      - name: molecule_db
+    mysql_users:
+      - name: molecule_user
+        host: "%"
+        password: "{{ mysql_molecule_user_password }}"
+        salt: "{{ mysql_molecule_user_salt }}"
+        priv: "molecule_db.*:ALL"
+  roles:
+    - role: tborealis.roles.mysql

--- a/roles/mysql/molecule/default/molecule.yml
+++ b/roles/mysql/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/mysql/molecule/default/vars.yml
+++ b/roles/mysql/molecule/default/vars.yml
@@ -1,0 +1,7 @@
+---
+# Throwaway test credentials shared by converge.yml and verify.yml.
+# The salts (exactly 20 characters) make the password tasks idempotent.
+mysql_root_password: molecule-Root-Passw0rd1
+mysql_root_password_salt: molecule0root0salt00
+mysql_molecule_user_password: molecule-User-Passw0rd1
+mysql_molecule_user_salt: molecule0user0salt00

--- a/roles/mysql/molecule/default/verify.yml
+++ b/roles/mysql/molecule/default/verify.yml
@@ -1,0 +1,51 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert MySQL service is running
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['mysql.service'].state == 'running'
+
+    - name: Query server info as root over the unix socket
+      ansible.mysql.mysql_info:
+        filter: version
+        login_user: root
+        login_password: "{{ mysql_root_password }}"
+        login_unix_socket: /var/run/mysqld/mysqld.sock
+      register: mysql_verify_info
+
+    - name: Assert MySQL 8.4 LTS is installed
+      ansible.builtin.assert:
+        that:
+          - mysql_verify_info.version.major | int == 8
+          - mysql_verify_info.version.minor | int == 4
+
+    - name: Log in as the created user over TCP and query the created database
+      ansible.builtin.command: >-
+        mysql --protocol=tcp --host=127.0.0.1
+        --user=molecule_user --password={{ mysql_molecule_user_password }}
+        molecule_db --execute='SELECT 1'
+      changed_when: false
+
+    - name: Read tuning config
+      ansible.builtin.slurp:
+        src: /etc/mysql/conf.d/tuning.cnf
+      register: mysql_verify_tuning
+
+    - name: Assert redo log capacity is configured
+      ansible.builtin.assert:
+        that:
+          - "'innodb_redo_log_capacity       = 256M' in mysql_verify_tuning.content | b64decode"
+
+    - name: Check the native-password migration shim was cleaned up
+      ansible.builtin.stat:
+        path: /etc/mysql/conf.d/native_password_migration.cnf
+      register: mysql_verify_shim
+      failed_when: mysql_verify_shim.stat.exists

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -132,6 +132,7 @@
     login_unix_socket: "{{ mysql_login_unix_socket }}"
     plugin: caching_sha2_password
     plugin_auth_string: "{{ mysql_root_password }}"
+    salt: "{{ mysql_root_password_salt | default(omit) }}"
     check_implicit_admin: true
     column_case_sensitive: true
 
@@ -164,6 +165,7 @@
     host: "{{ item.host | default('localhost') }}"
     plugin: caching_sha2_password
     plugin_auth_string: "{{ item.password }}"
+    salt: "{{ item.salt | default(omit) }}"
     priv: "{{ item.priv | default('*.*:USAGE') }}"
     state: present
     login_user: root

--- a/scripts/molecule_matrix.py
+++ b/scripts/molecule_matrix.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Generate the molecule CI job matrix.
+
+Modes:
+  --changed FILE   PR mode. FILE lists changed paths (one per line). A change
+                   under roles/<role>/ selects that role; a change to shared
+                   test infrastructure selects the canary set. Both accumulate.
+  --all            Every role with a molecule/ directory (weekly, dispatch).
+  --roles "a b"    Explicit space-separated role list (workflow_dispatch input).
+
+Writes GitHub Actions outputs to the file named by $GITHUB_OUTPUT (or stdout):
+  matrix=<json>        {"include": [{"role": ..., "distro": ...}, ...]}
+  any=<true|false>     whether the matrix has any jobs
+  build_image=<true|false>  whether docker/ changed (PR must build its own image)
+"""
+
+import argparse
+import json
+import os
+import sys
+
+import yaml
+
+DISTROS = ["bookworm", "trixie"]
+CANARY = ["git", "mysql"]  # one trivial, one heavy service role
+INFRA_PREFIXES = (
+    ".config/molecule/",
+    ".github/workflows/molecule.yml",
+    "requirements-dev.txt",
+    "requirements.yml",
+    "scripts/molecule_matrix.py",
+)
+IMAGE_PREFIX = "docker/"
+PLATFORMS_FILE = ".config/molecule/platforms.yml"
+
+
+def has_scenario(role):
+    return os.path.isdir(os.path.join("roles", role, "molecule"))
+
+
+def all_roles():
+    return sorted(r for r in os.listdir("roles") if has_scenario(r))
+
+
+def restrictions():
+    if not os.path.exists(PLATFORMS_FILE):
+        return {}
+    with open(PLATFORMS_FILE) as f:
+        return yaml.safe_load(f) or {}
+
+
+def roles_from_changes(paths):
+    roles = set()
+    infra = False
+    image = False
+    for p in paths:
+        if p.startswith("roles/") and p.count("/") >= 2:
+            roles.add(p.split("/", 2)[1])
+        elif p.startswith(IMAGE_PREFIX):
+            image = True
+            infra = True
+        elif p.startswith(INFRA_PREFIXES):
+            infra = True
+    roles = {r for r in roles if has_scenario(r)}
+    if infra:
+        roles.update(r for r in CANARY if has_scenario(r))
+    return sorted(roles), image
+
+
+def build_matrix(roles):
+    limits = restrictions()
+    return {
+        "include": [
+            {"role": r, "distro": d} for r in roles for d in limits.get(r, DISTROS)
+        ]
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--changed", metavar="FILE")
+    mode.add_argument("--all", action="store_true")
+    parser.add_argument("--roles", default="")
+    args = parser.parse_args()
+
+    image = False
+    if args.changed:
+        with open(args.changed) as f:
+            paths = [line.strip() for line in f if line.strip()]
+        roles, image = roles_from_changes(paths)
+    elif args.roles.strip():
+        roles = sorted(r for r in args.roles.split() if has_scenario(r))
+    else:
+        roles = all_roles()
+
+    matrix = build_matrix(roles)
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    out = open(out_path, "a") if out_path else sys.stdout
+    print(f"matrix={json.dumps(matrix)}", file=out)
+    print(f"any={'true' if matrix['include'] else 'false'}", file=out)
+    print(f"build_image={'true' if image else 'false'}", file=out)
+    print(f"Selected roles: {' '.join(roles) or '(none)'}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds functional testing to the collection, motivated by the mysql `no_log` bug (#116) that no amount of linting could catch.

- **Test images**: systemd-enabled `debian:bookworm`/`trixie` images built from `docker/molecule-debian/Dockerfile`, pushed to GHCR weekly and on Dockerfile changes (`test-images` workflow)
- **Shared molecule config** at `.config/molecule/config.yml`: docker driver, both releases, unprivileged systemd containers; per-role scenarios inherit it and stay tiny
- **CI** (`molecule` workflow): PRs test only the roles they touch (`scripts/molecule_matrix.py`; infra changes run a git+mysql canary, Dockerfile PRs test an image built from the branch); weekly full matrix with Slack alert; `workflow_dispatch` with role list
- **Local**: `make test ROLE=<name> [DISTRO=...]`, toolchain pinned in `requirements-dev.txt`; guide in `docs/testing.md`
- **Pilot scenarios**: `mysql` (root login over socket, TCP login as a role-created user — the no_log regression class — config assertions) and `git`

### Bugs found by the new tests

- **mysql was not idempotent**: `mysql_user` cannot compare a plaintext password against a stored `caching_sha2_password` hash, so every run rewrote root/user passwords. Fixed with optional `mysql_root_password_salt` / per-user `salt` (non-breaking, omitted = old behaviour).
- The collection artifact was packing the untracked local `.ansible/` directory; added to `build_ignore`.

### Validation

Both pilots pass converge → idempotence → verify on both releases locally; a deliberately broken assertion fails the run; lint passes (production profile); collection artifact verified clean.

### After merge

1. The `test-images` workflow pushes both images to GHCR (triggers on this merge)
2. **One-time manual step**: set the `molecule-debian` GHCR package visibility to public so unauthenticated pulls (local runs, future PR CI) work

Follow-up PRs add scenarios for the remaining ~35 roles in themed batches.