### PR TITLE
Add molecule scenarios for the web stack roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,13 @@ flagged with **BREAKING** and require a MAJOR version bump.
   characters). Without a salt the caching_sha2_password hash cannot be compared, so
   the root-password and user tasks reported changed on every run; providing one makes
   them idempotent.
+- **meta:** Molecule scenarios for the web stack roles: `nginx`, `apache2`, `ssl`,
+  `certbot`, and `php_repo_sury`.
 
 ### Fixed
+
+- **apache2:** the `apache2_env_vars` default was a list, which broke the role's own
+  envvars template (it iterates `.items()`); the default is now `{}`.
 
 - **mysql:** probe the root auth plugin with a fixed dummy password (the 1524 plugin
   error precedes password verification) so Ansible's `no_log` censoring can never

--- a/docker/molecule-debian/Dockerfile
+++ b/docker/molecule-debian/Dockerfile
@@ -20,6 +20,10 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /tmp/* /var/tmp/*
 
+# The base image blocks service starts during apt installs; real Debian
+# servers don't, and roles rely on packages starting their own units.
+RUN rm -f /usr/sbin/policy-rc.d
+
 # Trim units that hang, spam, or serve no purpose in a container.
 RUN find /etc/systemd/system /lib/systemd/system \
         \( -path '*.wants/*getty*' \

--- a/roles/apache2/README.md
+++ b/roles/apache2/README.md
@@ -14,4 +14,4 @@ Installs and configures Apache2 web server with virtual hosts and modules.
 | `apache2_packages` | `[apache2, apache2-utils, python3-passlib]` | Packages to install |
 | `apache2_modules` | `[proxy_fcgi, setenvif, rewrite, headers, ssl]` | Modules to enable |
 | `apache2_disable_modules` | `[mpm_prefork]` | Modules to disable |
-| `apache2_env_vars` | `[]` | Environment variables to set |
+| `apache2_env_vars` | `{}` | Environment variables to set |

--- a/roles/apache2/defaults/main.yml
+++ b/roles/apache2/defaults/main.yml
@@ -20,4 +20,4 @@ apache2_modules:
 apache2_disable_modules:
   - mpm_prefork
 
-apache2_env_vars: []
+apache2_env_vars: {}

--- a/roles/apache2/molecule/default/converge.yml
+++ b/roles/apache2/molecule/default/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    apache2_vhosts:
+      - src: molecule.conf.j2
+        dest: molecule.conf
+    apache2_basic_auth:
+      - name: "{{ apache2_molecule_auth_user }}"
+        password: "{{ apache2_molecule_auth_password }}"
+    # Must be a mapping: the role's envvars template iterates
+    # apache2_env_vars.items(), which fails on the [] default.
+    apache2_env_vars:
+      APACHE_MOLECULE_MARKER: molecule
+  roles:
+    - role: tborealis.roles.apache2

--- a/roles/apache2/molecule/default/molecule.yml
+++ b/roles/apache2/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/apache2/molecule/default/prepare.yml
+++ b/roles/apache2/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+# The converge vhost serves static files; providing web content is outside
+# the role's contract, so create the docroot fixture here.
+- name: Prepare
+  hosts: all
+  become: true
+  tasks:
+    - name: Create docroot directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - /var/www/molecule
+        - /var/www/molecule/secure
+
+    - name: Write index pages
+      ansible.builtin.copy:
+        content: "{{ item.content }}\n"
+        dest: "{{ item.dest }}"
+        mode: "0644"
+      loop:
+        - dest: /var/www/molecule/index.html
+          content: molecule vhost ok
+        - dest: /var/www/molecule/secure/index.html
+          content: molecule secure ok
+      loop_control:
+        label: "{{ item.dest }}"

--- a/roles/apache2/molecule/default/templates/apache2/vhosts/molecule.conf.j2
+++ b/roles/apache2/molecule/default/templates/apache2/vhosts/molecule.conf.j2
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+    ServerName molecule.test
+    DocumentRoot /var/www/molecule
+
+    <Directory /var/www/molecule>
+        Require all granted
+    </Directory>
+
+    <Location /secure>
+        AuthType Basic
+        AuthName "Molecule restricted"
+        AuthUserFile /etc/apache2/htpassword
+        Require valid-user
+    </Location>
+</VirtualHost>

--- a/roles/apache2/molecule/default/vars.yml
+++ b/roles/apache2/molecule/default/vars.yml
@@ -1,0 +1,4 @@
+---
+# Throwaway test credentials shared by converge.yml and verify.yml.
+apache2_molecule_auth_user: molecule
+apache2_molecule_auth_password: molecule-Basic-Passw0rd1

--- a/roles/apache2/molecule/default/verify.yml
+++ b/roles/apache2/molecule/default/verify.yml
@@ -1,0 +1,100 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert apache2 service is running
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['apache2.service'].state == 'running'
+
+    - name: Validate Apache configuration # noqa: command-instead-of-module (functional check of the deployed config)
+      ansible.builtin.command: apache2ctl configtest
+      changed_when: false
+
+    - name: List loaded Apache modules # noqa: command-instead-of-module (functional check that modules are loaded)
+      ansible.builtin.command: apache2ctl -M
+      register: apache2_verify_modules
+      changed_when: false
+
+    - name: Assert module state matches the role variables
+      ansible.builtin.assert:
+        that:
+          - "'mpm_event_module' in apache2_verify_modules.stdout"
+          - "'mpm_prefork_module' not in apache2_verify_modules.stdout"
+          - "'rewrite_module' in apache2_verify_modules.stdout"
+          - "'ssl_module' in apache2_verify_modules.stdout"
+          - "'proxy_fcgi_module' in apache2_verify_modules.stdout"
+
+    - name: Request the vhost root
+      ansible.builtin.uri:
+        url: http://127.0.0.1/
+        return_content: true
+      register: apache2_verify_root
+
+    - name: Assert the vhost serves the fixture content
+      ansible.builtin.assert:
+        that:
+          - apache2_verify_root.status == 200
+          - "'molecule vhost ok' in apache2_verify_root.content"
+
+    - name: Request the protected location without credentials
+      ansible.builtin.uri:
+        url: http://127.0.0.1/secure/
+        status_code: 401
+
+    - name: Request the protected location with credentials
+      ansible.builtin.uri:
+        url: http://127.0.0.1/secure/
+        url_username: "{{ apache2_molecule_auth_user }}"
+        url_password: "{{ apache2_molecule_auth_password }}"
+        force_basic_auth: true
+        return_content: true
+      register: apache2_verify_auth
+
+    - name: Assert basic auth grants access
+      ansible.builtin.assert:
+        that:
+          - "'molecule secure ok' in apache2_verify_auth.content"
+
+    - name: Read the installed vhost
+      ansible.builtin.slurp:
+        src: /etc/apache2/sites-available/molecule.conf
+      register: apache2_verify_vhost
+
+    - name: Assert the converge vhost was installed
+      ansible.builtin.assert:
+        that:
+          - "'ServerName molecule.test' in apache2_verify_vhost.content | b64decode"
+
+    - name: Check vhost symlink
+      ansible.builtin.stat:
+        path: /etc/apache2/sites-enabled/molecule.conf
+      register: apache2_verify_vhost_link
+
+    - name: Assert vhost is enabled from sites-available
+      ansible.builtin.assert:
+        that:
+          - apache2_verify_vhost_link.stat.islnk
+          - apache2_verify_vhost_link.stat.lnk_source == '/etc/apache2/sites-available/molecule.conf'
+
+    - name: Read the environment config
+      ansible.builtin.slurp:
+        src: /etc/apache2/envvars
+      register: apache2_verify_envvars
+
+    - name: Assert the converge environment variable is exported
+      ansible.builtin.assert:
+        that:
+          - "\"export APACHE_MOLECULE_MARKER='molecule'\" in apache2_verify_envvars.content | b64decode"
+
+    - name: Check default site was disabled
+      ansible.builtin.stat:
+        path: /etc/apache2/sites-enabled/000-default.conf
+      register: apache2_verify_default_site
+      failed_when: apache2_verify_default_site.stat.exists

--- a/roles/certbot/molecule/default/converge.yml
+++ b/roles/certbot/molecule/default/converge.yml
@@ -1,0 +1,14 @@
+---
+# Certificate issuance needs a real ACME challenge, which is impossible in the
+# container, so certbot_certs stays empty (its default) and the scenario tests
+# what the role manages locally: the certbot package, the DNS plugin (apt on
+# bookworm, pip on trixie), and the credentials file.
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    certbot_mode: dns-digitalocean
+  roles:
+    - role: tborealis.roles.certbot

--- a/roles/certbot/molecule/default/molecule.yml
+++ b/roles/certbot/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/certbot/molecule/default/vars.yml
+++ b/roles/certbot/molecule/default/vars.yml
@@ -1,0 +1,5 @@
+---
+# Throwaway test credential shared by converge.yml and verify.yml. Deliberately
+# NOT shaped like a real DigitalOcean token so secret scanning cannot mistake
+# it for one; no ACME requests are made because certbot_certs stays empty.
+certbot_digitalocean_dns_token: molecule-fake-do-token-0123456789

--- a/roles/certbot/molecule/default/verify.yml
+++ b/roles/certbot/molecule/default/verify.yml
@@ -1,0 +1,63 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Run certbot # noqa: command-instead-of-module (functional check that the binary works)
+      ansible.builtin.command: certbot --version
+      changed_when: false
+
+    - name: List certbot plugins
+      ansible.builtin.command: certbot plugins
+      register: certbot_verify_plugins
+      changed_when: false
+
+    - name: Assert DigitalOcean DNS plugin is registered with certbot
+      ansible.builtin.assert:
+        that:
+          - "'dns-digitalocean' in certbot_verify_plugins.stdout"
+
+    - name: Check renewal timer state # noqa: command-instead-of-module (service_facts does not report timer units)
+      ansible.builtin.command: systemctl is-active certbot.timer
+      register: certbot_verify_timer_active
+      changed_when: false
+      failed_when: false
+
+    - name: Check renewal timer enablement # noqa: command-instead-of-module (service_facts does not report timer units)
+      ansible.builtin.command: systemctl is-enabled certbot.timer
+      register: certbot_verify_timer_enabled
+      changed_when: false
+      failed_when: false
+
+    - name: Assert renewal timer is active and enabled
+      ansible.builtin.assert:
+        that:
+          - certbot_verify_timer_active.stdout == 'active'
+          - certbot_verify_timer_enabled.stdout == 'enabled'
+
+    - name: Stat DigitalOcean credentials file
+      ansible.builtin.stat:
+        path: /etc/letsencrypt/digitalocean.ini
+      register: certbot_verify_credentials_stat
+
+    - name: Assert credentials file is root-owned and private
+      ansible.builtin.assert:
+        that:
+          - certbot_verify_credentials_stat.stat.exists
+          - certbot_verify_credentials_stat.stat.pw_name == 'root'
+          - certbot_verify_credentials_stat.stat.gr_name == 'root'
+          - certbot_verify_credentials_stat.stat.mode == '0600'
+
+    - name: Read DigitalOcean credentials file
+      ansible.builtin.slurp:
+        src: /etc/letsencrypt/digitalocean.ini
+      register: certbot_verify_credentials
+
+    - name: Assert the configured token is written to the credentials file
+      ansible.builtin.assert:
+        that:
+          - >-
+            'dns_digitalocean_token = "' ~ certbot_digitalocean_dns_token ~ '"'
+            in certbot_verify_credentials.content | b64decode

--- a/roles/nginx/molecule/default/converge.yml
+++ b/roles/nginx/molecule/default/converge.yml
@@ -1,0 +1,18 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    nginx_client_max_body_size: 16m
+    nginx_vhosts:
+      - src: molecule.conf.j2
+        dest: molecule.conf
+        enabled: true
+    nginx_basic_auth:
+      - name: "{{ nginx_molecule_auth_user }}"
+        password: "{{ nginx_molecule_auth_password }}"
+        path: "{{ nginx_molecule_htpasswd_path }}"
+  roles:
+    - role: tborealis.roles.nginx

--- a/roles/nginx/molecule/default/molecule.yml
+++ b/roles/nginx/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/nginx/molecule/default/prepare.yml
+++ b/roles/nginx/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+# The converge vhost serves static files; providing web content is outside
+# the role's contract, so create the docroot fixture here.
+- name: Prepare
+  hosts: all
+  become: true
+  tasks:
+    - name: Create docroot directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - /var/www/molecule
+        - /var/www/molecule/secure
+
+    - name: Write index pages
+      ansible.builtin.copy:
+        content: "{{ item.content }}\n"
+        dest: "{{ item.dest }}"
+        mode: "0644"
+      loop:
+        - dest: /var/www/molecule/index.html
+          content: molecule vhost ok
+        - dest: /var/www/molecule/secure/index.html
+          content: molecule secure ok
+      loop_control:
+        label: "{{ item.dest }}"

--- a/roles/nginx/molecule/default/templates/nginx/vhosts/molecule.conf.j2
+++ b/roles/nginx/molecule/default/templates/nginx/vhosts/molecule.conf.j2
@@ -1,0 +1,19 @@
+#
+# {{ ansible_managed }}
+#
+
+server {
+    listen 80 default_server;
+    server_name molecule.test;
+
+    root /var/www/molecule;
+    index index.html;
+
+    location / {
+    }
+
+    location /secure/ {
+        auth_basic "Molecule restricted";
+        auth_basic_user_file {{ nginx_molecule_htpasswd_path }};
+    }
+}

--- a/roles/nginx/molecule/default/vars.yml
+++ b/roles/nginx/molecule/default/vars.yml
@@ -1,0 +1,5 @@
+---
+# Throwaway test credentials shared by converge.yml and verify.yml.
+nginx_molecule_auth_user: molecule
+nginx_molecule_auth_password: molecule-Basic-Passw0rd1
+nginx_molecule_htpasswd_path: /etc/nginx/.htpasswd-molecule

--- a/roles/nginx/molecule/default/verify.yml
+++ b/roles/nginx/molecule/default/verify.yml
@@ -1,0 +1,78 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert nginx service is running
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['nginx.service'].state == 'running'
+
+    - name: Validate nginx configuration
+      ansible.builtin.command: nginx -t
+      changed_when: false
+
+    - name: Request the vhost root
+      ansible.builtin.uri:
+        url: http://127.0.0.1/
+        return_content: true
+      register: nginx_verify_root
+
+    - name: Assert the vhost serves content and hides the server version
+      ansible.builtin.assert:
+        that:
+          - nginx_verify_root.status == 200
+          - "'molecule vhost ok' in nginx_verify_root.content"
+          - nginx_verify_root.server == 'nginx'
+
+    - name: Request the protected location without credentials
+      ansible.builtin.uri:
+        url: http://127.0.0.1/secure/
+        status_code: 401
+
+    - name: Request the protected location with credentials
+      ansible.builtin.uri:
+        url: http://127.0.0.1/secure/
+        url_username: "{{ nginx_molecule_auth_user }}"
+        url_password: "{{ nginx_molecule_auth_password }}"
+        force_basic_auth: true
+        return_content: true
+      register: nginx_verify_auth
+
+    - name: Assert basic auth grants access
+      ansible.builtin.assert:
+        that:
+          - "'molecule secure ok' in nginx_verify_auth.content"
+
+    - name: Read nginx.conf
+      ansible.builtin.slurp:
+        src: /etc/nginx/nginx.conf
+      register: nginx_verify_conf
+
+    - name: Assert converge values are rendered into nginx.conf
+      ansible.builtin.assert:
+        that:
+          - "'client_max_body_size 16m;' in nginx_verify_conf.content | b64decode"
+          - "'server_tokens off;' in nginx_verify_conf.content | b64decode"
+
+    - name: Check vhost symlink
+      ansible.builtin.stat:
+        path: /etc/nginx/sites-enabled/molecule.conf
+      register: nginx_verify_vhost_link
+
+    - name: Assert vhost is enabled from sites-available
+      ansible.builtin.assert:
+        that:
+          - nginx_verify_vhost_link.stat.islnk
+          - nginx_verify_vhost_link.stat.lnk_source == '/etc/nginx/sites-available/molecule.conf'
+
+    - name: Check default site was removed
+      ansible.builtin.stat:
+        path: /etc/nginx/conf.d/default.conf
+      register: nginx_verify_default_site
+      failed_when: nginx_verify_default_site.stat.exists

--- a/roles/php_repo_sury/molecule/default/converge.yml
+++ b/roles/php_repo_sury/molecule/default/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    php_version: "{{ php_repo_sury_test_version }}"
+    php_cli_xdebug: true
+  roles:
+    - role: tborealis.roles.php_repo_sury
+  tasks:
+    # The role only configures the repository; installing a package from it
+    # is the functional proof that the repo works (php_cli does this on real
+    # hosts). CLI only, to keep the scenario fast.
+    - name: Install PHP CLI from the Sury repository
+      ansible.builtin.apt:
+        pkg: "php{{ php_repo_sury_test_version }}-cli"
+        state: present

--- a/roles/php_repo_sury/molecule/default/molecule.yml
+++ b/roles/php_repo_sury/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/php_repo_sury/molecule/default/vars.yml
+++ b/roles/php_repo_sury/molecule/default/vars.yml
@@ -1,0 +1,5 @@
+---
+# PHP version shared by converge.yml and verify.yml. 8.3 is shipped by
+# neither bookworm (8.2) nor trixie (8.4), so a working php8.3-cli proves
+# the package really came from the Sury repository.
+php_repo_sury_test_version: "8.3"

--- a/roles/php_repo_sury/molecule/default/verify.yml
+++ b/roles/php_repo_sury/molecule/default/verify.yml
@@ -1,0 +1,61 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Run php # noqa: command-instead-of-module (functional check that the binary works)
+      ansible.builtin.command: php -v
+      register: php_repo_sury_verify_php
+      changed_when: false
+
+    - name: Assert the requested PHP version is installed
+      ansible.builtin.assert:
+        that:
+          - php_repo_sury_verify_php.stdout is search('^PHP ' ~ php_repo_sury_test_version ~ '\.')
+
+    - name: Check apt policy for the CLI package of PHP {{ php_repo_sury_test_version }}
+      ansible.builtin.command: apt-cache policy php{{ php_repo_sury_test_version }}-cli
+      register: php_repo_sury_verify_policy
+      changed_when: false
+
+    - name: Assert the package was installed from the Sury repository
+      ansible.builtin.assert:
+        that:
+          - "'packages.sury.org' in php_repo_sury_verify_policy.stdout"
+
+    - name: Read the Sury deb822 source
+      ansible.builtin.slurp:
+        src: /etc/apt/sources.list.d/php-sury.sources
+      register: php_repo_sury_verify_source
+
+    - name: Assert the source targets the Sury repo for this release
+      ansible.builtin.assert:
+        that:
+          - "'URIs: https://packages.sury.org/php/' in php_repo_sury_verify_source.content | b64decode"
+          - "'Suites: ' ~ ansible_facts['distribution_release'] in php_repo_sury_verify_source.content | b64decode"
+          - "'Signed-By: /etc/apt/keyrings/php-sury-repo.gpg' in php_repo_sury_verify_source.content | b64decode"
+
+    - name: Stat the xdebug-enable control script
+      ansible.builtin.stat:
+        path: /usr/local/bin/xdebug-enable
+      register: php_repo_sury_verify_xdebug_stat
+
+    - name: Assert the control script is executable and root-owned
+      ansible.builtin.assert:
+        that:
+          - php_repo_sury_verify_xdebug_stat.stat.exists
+          - php_repo_sury_verify_xdebug_stat.stat.mode == '0755'
+          - php_repo_sury_verify_xdebug_stat.stat.pw_name == 'root'
+
+    - name: Read the xdebug-enable control script
+      ansible.builtin.slurp:
+        src: /usr/local/bin/xdebug-enable
+      register: php_repo_sury_verify_xdebug_script
+
+    - name: Assert the control script targets the requested PHP version
+      ansible.builtin.assert:
+        that:
+          - "'/etc/php/' ~ php_repo_sury_test_version ~ '/mods-available/xdebug.ini'
+             in php_repo_sury_verify_xdebug_script.content | b64decode"

--- a/roles/ssl/molecule/default/converge.yml
+++ b/roles/ssl/molecule/default/converge.yml
@@ -1,0 +1,34 @@
+---
+# The role no-ops on defaults, so feed it the throwaway material generated
+# in prepare. slurp returns base64, which is exactly what the role's
+# `data` fields expect. Idempotence re-runs this play only; the slurped
+# fixtures are stable, so the second converge copies identical content.
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  pre_tasks:
+    - name: Read throwaway private key generated in prepare
+      ansible.builtin.slurp:
+        src: "{{ ssl_molecule_fixture_dir }}/{{ ssl_molecule_cert_name }}.key"
+      register: ssl_molecule_key
+
+    - name: Read throwaway certificate generated in prepare
+      ansible.builtin.slurp:
+        src: "{{ ssl_molecule_fixture_dir }}/{{ ssl_molecule_cert_name }}.pem"
+      register: ssl_molecule_cert
+
+    - name: Stage the role's input variables
+      ansible.builtin.set_fact:
+        ssl_keys:
+          - name: "{{ ssl_molecule_cert_name }}"
+            data: "{{ ssl_molecule_key.content }}"
+        ssl_certs:
+          - name: "{{ ssl_molecule_cert_name }}"
+            data: "{{ ssl_molecule_cert.content }}"
+        ssl_stapling:
+          - name: "{{ ssl_molecule_cert_name }}"
+            data: "{{ ssl_molecule_cert.content }}"
+  roles:
+    - role: tborealis.roles.ssl

--- a/roles/ssl/molecule/default/molecule.yml
+++ b/roles/ssl/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/ssl/molecule/default/prepare.yml
+++ b/roles/ssl/molecule/default/prepare.yml
@@ -1,0 +1,36 @@
+---
+# The role copies pre-existing key/cert material and chowns it to the
+# ssl-cert group, which the ssl-cert package provides on real hosts.
+# Generate a throwaway self-signed certificate on the target; converge
+# slurps it into the role's content variables. The creates: guard keeps
+# the material stable if prepare ever re-runs.
+- name: Prepare
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Install openssl and the ssl-cert package (provides the ssl-cert group)
+      ansible.builtin.apt:
+        pkg:
+          - openssl
+          - ssl-cert
+        state: present
+        update_cache: true
+
+    - name: Create fixture directory
+      ansible.builtin.file:
+        path: "{{ ssl_molecule_fixture_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0700"
+
+    - name: Generate throwaway self-signed certificate and key
+      ansible.builtin.command: >-
+        openssl req -x509 -newkey rsa:2048 -nodes
+        -keyout {{ ssl_molecule_fixture_dir }}/{{ ssl_molecule_cert_name }}.key
+        -out {{ ssl_molecule_fixture_dir }}/{{ ssl_molecule_cert_name }}.pem
+        -days 365 -subj /CN={{ ssl_molecule_cert_cn }}
+      args:
+        creates: "{{ ssl_molecule_fixture_dir }}/{{ ssl_molecule_cert_name }}.key"

--- a/roles/ssl/molecule/default/vars.yml
+++ b/roles/ssl/molecule/default/vars.yml
@@ -1,0 +1,5 @@
+---
+# Shared between prepare.yml, converge.yml and verify.yml.
+ssl_molecule_fixture_dir: /root/molecule-ssl-fixtures
+ssl_molecule_cert_name: molecule
+ssl_molecule_cert_cn: molecule.example.com

--- a/roles/ssl/molecule/default/verify.yml
+++ b/roles/ssl/molecule/default/verify.yml
@@ -1,0 +1,120 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Stat installed private key
+      ansible.builtin.stat:
+        path: "/etc/ssl/private/{{ ssl_molecule_cert_name }}.key"
+      register: ssl_verify_key_stat
+
+    - name: Assert key is root/ssl-cert owned and not world-readable
+      ansible.builtin.assert:
+        that:
+          - ssl_verify_key_stat.stat.exists
+          - ssl_verify_key_stat.stat.pw_name == 'root'
+          - ssl_verify_key_stat.stat.gr_name == 'ssl-cert'
+          - ssl_verify_key_stat.stat.mode == '0640'
+
+    - name: Stat installed certificate
+      ansible.builtin.stat:
+        path: "/etc/ssl/certs/{{ ssl_molecule_cert_name }}.pem"
+      register: ssl_verify_cert_stat
+
+    - name: Assert certificate is root-owned and world-readable
+      ansible.builtin.assert:
+        that:
+          - ssl_verify_cert_stat.stat.exists
+          - ssl_verify_cert_stat.stat.pw_name == 'root'
+          - ssl_verify_cert_stat.stat.gr_name == 'root'
+          - ssl_verify_cert_stat.stat.mode == '0644'
+
+    - name: Read installed private key
+      ansible.builtin.slurp:
+        src: "/etc/ssl/private/{{ ssl_molecule_cert_name }}.key"
+      register: ssl_verify_key
+
+    - name: Assert key is PEM-encoded
+      ansible.builtin.assert:
+        that:
+          - "'BEGIN PRIVATE KEY' in ssl_verify_key.content | b64decode"
+
+    - name: Read installed certificate
+      ansible.builtin.slurp:
+        src: "/etc/ssl/certs/{{ ssl_molecule_cert_name }}.pem"
+      register: ssl_verify_cert
+
+    - name: Read fixture certificate for comparison
+      ansible.builtin.slurp:
+        src: "{{ ssl_molecule_fixture_dir }}/{{ ssl_molecule_cert_name }}.pem"
+      register: ssl_verify_fixture_cert
+
+    - name: Assert installed certificate is PEM-encoded and matches the fixture
+      ansible.builtin.assert:
+        that:
+          - "'BEGIN CERTIFICATE' in ssl_verify_cert.content | b64decode"
+          - ssl_verify_cert.content == ssl_verify_fixture_cert.content
+
+    - name: Read installed stapling certificate
+      ansible.builtin.slurp:
+        src: "/etc/ssl/certs/{{ ssl_molecule_cert_name }}.stapling.pem"
+      register: ssl_verify_stapling
+
+    - name: Assert stapling certificate is PEM-encoded
+      ansible.builtin.assert:
+        that:
+          - "'BEGIN CERTIFICATE' in ssl_verify_stapling.content | b64decode"
+
+    - name: Validate installed certificate with openssl
+      ansible.builtin.command: >-
+        openssl x509 -noout -subject
+        -in /etc/ssl/certs/{{ ssl_molecule_cert_name }}.pem
+      register: ssl_verify_x509
+      changed_when: false
+
+    - name: Assert certificate subject carries the test CN
+      ansible.builtin.assert:
+        that:
+          - ssl_molecule_cert_cn in ssl_verify_x509.stdout
+
+    - name: Assert installed key matches the installed certificate
+      ansible.builtin.shell: >-
+        set -o pipefail;
+        cmp
+        <(openssl x509 -noout -pubkey -in /etc/ssl/certs/{{ ssl_molecule_cert_name }}.pem)
+        <(openssl pkey -pubout -in /etc/ssl/private/{{ ssl_molecule_cert_name }}.key)
+      args:
+        executable: /bin/bash
+      changed_when: false
+
+    - name: Stat DH params directory
+      ansible.builtin.stat:
+        path: /etc/ssl/dh
+      register: ssl_verify_dh_dir
+
+    - name: Assert DH directory permissions
+      ansible.builtin.assert:
+        that:
+          - ssl_verify_dh_dir.stat.isdir
+          - ssl_verify_dh_dir.stat.pw_name == 'root'
+          - ssl_verify_dh_dir.stat.gr_name == 'ssl-cert'
+          - ssl_verify_dh_dir.stat.mode == '0710'
+
+    - name: Stat generated DH params
+      ansible.builtin.stat:
+        path: /etc/ssl/dh/dhparam.pem
+      register: ssl_verify_dh_stat
+
+    - name: Assert DH params are root/ssl-cert owned and not world-readable
+      ansible.builtin.assert:
+        that:
+          - ssl_verify_dh_stat.stat.exists
+          - ssl_verify_dh_stat.stat.pw_name == 'root'
+          - ssl_verify_dh_stat.stat.gr_name == 'ssl-cert'
+          - ssl_verify_dh_stat.stat.mode == '0640'
+
+    - name: Validate DH params with openssl
+      ansible.builtin.command: openssl dhparam -in /etc/ssl/dh/dhparam.pem -check -noout
+      changed_when: false


### PR DESCRIPTION
## Summary

Batch 2 of the testing rollout: Molecule scenarios for **nginx**, **apache2**, **ssl**, **certbot**, and **php_repo_sury**. All five pass converge → idempotence → verify on bookworm and trixie locally.

### Bugs found and fixed

- **apache2** failed on pure defaults: `apache2_env_vars` defaulted to `[]` but the role's own `envvars.j2` iterates `.items()`. Default is now `{}`.
- The test images shipped the Docker base's `policy-rc.d` (exit 101), which blocks package postinst from starting units (caught by certbot's renewal-timer assertion). Removed — real Debian servers don't have it.

### Scenario highlights

- nginx/apache2: vhost fixtures with basic auth verified functionally (401 without credentials, 200 with), config-content assertions, `nginx -t`/`apache2ctl configtest`
- ssl: prepare-generated throwaway cert; verifies modes/ownership, that the installed key matches the installed cert, and DH params
- certbot: dns-digitalocean mode with a dummy token; verifies plugin registration, renewal timer, credentials file
- php_repo_sury: installs PHP 8.3 (neither release ships it, so a working `php8.3-cli` proves the Sury repo), asserts package origin and deb822 content

### Pre-existing issues noticed but not touched

- certbot `apache` mode references unprefixed `apache2_ssl_vhosts` and a handler the role doesn't ship
- apache2 `apache2_load_modules`/`apache2_conf` variables are unused by any task
- nginx/apache2 never explicitly start their services (rely on handlers/postinst)

Since this touches `docker/`, CI builds the test image from this branch (plus the git+mysql canary).