### PR TITLE
Add molecule scenarios for the PHP stack roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,19 @@ flagged with **BREAKING** and require a MAJOR version bump.
   them idempotent.
 - **meta:** Molecule scenarios for the web stack roles: `nginx`, `apache2`, `ssl`,
   `certbot`, and `php_repo_sury`.
+- **meta:** Molecule scenarios for the PHP stack roles: `php_cli`, `php_fpm`,
+  `composer`, `phpbu`, `new_relic`, and `symfony_params`.
 
 ### Fixed
 
 - **apache2:** the `apache2_env_vars` default was a list, which broke the role's own
   envvars template (it iterates `.items()`); the default is now `{}`.
+- **composer:** `composer_global_packages` entries failed because the composer module
+  rejects arguments embedded in the command string; the task now uses the `arguments`
+  and `global_command` parameters.
+- **phpbu:** the phar and schema are fetched from GitHub; `phar.phpbu.de` fails its
+  TLS handshake and `schema.phpbu.de` no longer resolves, so the role could not
+  converge. The pinned version and checksum are unchanged.
 
 - **mysql:** probe the root auth plugin with a fixed dummy password (the 1524 plugin
   error precedes password verification) so Ansible's `no_log` censoring can never

--- a/roles/composer/molecule/default/converge.yml
+++ b/roles/composer/molecule/default/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    composer_php_version: "8.3"
+    # phpstan ships as a single dependency-free package with a binary,
+    # keeping the global-install download small but still runnable.
+    composer_global_packages:
+      - name: phpstan/phpstan
+        version: "2.1.*"
+  roles:
+    - role: tborealis.roles.composer

--- a/roles/composer/molecule/default/molecule.yml
+++ b/roles/composer/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/composer/molecule/default/prepare.yml
+++ b/roles/composer/molecule/default/prepare.yml
@@ -1,0 +1,14 @@
+---
+# The role runs the Composer installer with PHP but does not install PHP
+# itself. Real playbooks apply php_repo_sury and php_cli first, so mirror
+# that order here: add the sury repo, then install a PHP CLI.
+- name: Prepare
+  hosts: all
+  become: true
+  roles:
+    - role: tborealis.roles.php_repo_sury
+  tasks:
+    - name: Install PHP CLI
+      ansible.builtin.apt:
+        pkg: php8.3-cli
+        state: present

--- a/roles/composer/molecule/default/verify.yml
+++ b/roles/composer/molecule/default/verify.yml
@@ -1,0 +1,41 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  environment:
+    COMPOSER_ALLOW_SUPERUSER: "1"
+  tasks:
+    - name: Run composer # noqa: command-instead-of-module (functional check that the binary works)
+      ansible.builtin.command: composer --version
+      register: composer_verify_version
+      changed_when: false
+
+    - name: Assert Composer 2 is installed
+      ansible.builtin.assert:
+        that:
+          - "'Composer version 2' in composer_verify_version.stdout"
+
+    - name: Get the global bin directory # noqa: command-instead-of-module (probing composer's own config)
+      ansible.builtin.command: composer global config --absolute bin-dir
+      register: composer_verify_bin_dir
+      changed_when: false
+
+    - name: Run the globally installed phpstan
+      ansible.builtin.command: "{{ composer_verify_bin_dir.stdout_lines | last }}/phpstan --version"
+      register: composer_verify_phpstan
+      changed_when: false
+
+    - name: Assert phpstan reports its version
+      ansible.builtin.assert:
+        that:
+          - "'PHPStan' in composer_verify_phpstan.stdout"
+
+    - name: Read bash completion script
+      ansible.builtin.slurp:
+        src: /etc/bash_completion.d/composer
+      register: composer_verify_completion
+
+    - name: Assert completion script registers composer
+      ansible.builtin.assert:
+        that:
+          - "'complete' in composer_verify_completion.content | b64decode"

--- a/roles/composer/tasks/main.yml
+++ b/roles/composer/tasks/main.yml
@@ -37,7 +37,8 @@
 
 - name: Install Composer global packages
   community.general.composer:
-    command: 'global require "{{ item.name }}={{ item.version }}"'
+    command: require
+    global_command: true
+    arguments: "{{ item.name }}={{ item.version }}"
     prefer_dist: true
-    working_dir: /
   with_items: "{{ composer_global_packages }}"

--- a/roles/new_relic/molecule/default/converge.yml
+++ b/roles/new_relic/molecule/default/converge.yml
@@ -1,0 +1,15 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  roles:
+    - role: tborealis.roles.new_relic
+  # The role notifies this handler but does not define it; on real hosts it is
+  # owned by the php_fpm role.
+  handlers:
+    - name: Restart php-fpm
+      ansible.builtin.service:
+        name: php{{ php_version }}-fpm
+        state: restarted

--- a/roles/new_relic/molecule/default/molecule.yml
+++ b/roles/new_relic/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/new_relic/molecule/default/prepare.yml
+++ b/roles/new_relic/molecule/default/prepare.yml
@@ -1,0 +1,19 @@
+---
+# The role templates its ini into /etc/php/<version>/mods-available and
+# notifies a php-fpm restart, so PHP must already be installed (the
+# php_repo_sury and php_fpm roles do this on real hosts).
+- name: Prepare
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  roles:
+    - role: tborealis.roles.php_repo_sury
+  tasks:
+    - name: Install PHP {{ php_version }}
+      ansible.builtin.apt:
+        pkg:
+          - php{{ php_version }}-cli
+          - php{{ php_version }}-fpm
+        state: present
+        update_cache: true

--- a/roles/new_relic/molecule/default/vars.yml
+++ b/roles/new_relic/molecule/default/vars.yml
@@ -1,0 +1,7 @@
+---
+# Test values shared by prepare.yml, converge.yml and verify.yml. The license
+# key is a dummy with a realistic shape (40 hex characters); the agent cannot
+# authenticate with it, so verification never asserts daemon connectivity.
+php_version: "8.3"
+newrelic_key: "0123456789abcdef0123456789abcdefdeadbeef"
+newrelic_appname: Molecule Test App

--- a/roles/new_relic/molecule/default/verify.yml
+++ b/roles/new_relic/molecule/default/verify.yml
@@ -1,0 +1,58 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+
+    - name: Assert the New Relic PHP agent package is installed
+      ansible.builtin.assert:
+        that:
+          - "'newrelic-php5' in ansible_facts.packages"
+
+    - name: Stat the New Relic apt source
+      ansible.builtin.stat:
+        path: /etc/apt/sources.list.d/newrelic.sources
+      register: new_relic_verify_source
+
+    - name: Assert the deb822 apt source is installed
+      ansible.builtin.assert:
+        that:
+          - new_relic_verify_source.stat.exists
+
+    - name: Stat the agent ini file
+      ansible.builtin.stat:
+        path: /etc/php/{{ php_version }}/mods-available/newrelic.ini
+      register: new_relic_verify_ini_stat
+
+    - name: Assert ini ownership and mode
+      ansible.builtin.assert:
+        that:
+          - new_relic_verify_ini_stat.stat.exists
+          - new_relic_verify_ini_stat.stat.pw_name == 'root'
+          - new_relic_verify_ini_stat.stat.gr_name == 'root'
+          - new_relic_verify_ini_stat.stat.mode == '0644'
+
+    - name: Read the agent ini file
+      ansible.builtin.slurp:
+        src: /etc/php/{{ php_version }}/mods-available/newrelic.ini
+      register: new_relic_verify_ini
+
+    - name: Assert converge values are rendered in the ini
+      vars:
+        new_relic_verify_ini_content: "{{ new_relic_verify_ini.content | b64decode }}"
+        new_relic_verify_expected_license: 'newrelic.license = "{{ newrelic_key }}"'
+        new_relic_verify_expected_appname: 'newrelic.appname = "{{ newrelic_appname }}"'
+      ansible.builtin.assert:
+        that:
+          - new_relic_verify_expected_license in new_relic_verify_ini_content
+          - new_relic_verify_expected_appname in new_relic_verify_ini_content
+          - "'newrelic.browser_monitoring.auto_instrument = false' in new_relic_verify_ini_content"
+          - "'newrelic.distributed_tracing_enabled = true' in new_relic_verify_ini_content"
+
+    - name: Validate the PHP-FPM configuration with the agent installed
+      ansible.builtin.command: /usr/sbin/php-fpm{{ php_version }} -t
+      changed_when: false

--- a/roles/php_cli/molecule/default/converge.yml
+++ b/roles/php_cli/molecule/default/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    php_version: "{{ php_cli_test_version }}"
+    php_cli_date_timezone: Pacific/Auckland
+    php_cli_error_reporting: E_ALL
+    php_cli_error_log: /var/log/php-cli-molecule.log
+    php_cli_xdebug: true
+    php_cli_xdebug_client_host: 192.0.2.10
+    php_cli_xdebug_idekey: molecule
+    php_cli_xdebug_max_nesting_level: 512
+    php_cli_packages:
+      - "php{{ php_cli_test_version }}-curl"
+  roles:
+    - role: tborealis.roles.php_cli

--- a/roles/php_cli/molecule/default/molecule.yml
+++ b/roles/php_cli/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/php_cli/molecule/default/prepare.yml
+++ b/roles/php_cli/molecule/default/prepare.yml
@@ -1,0 +1,13 @@
+---
+# The role installs php<version>-cli itself, but that package only exists in
+# the Sury repository; on real hosts php_repo_sury runs earlier in the
+# playbook.
+- name: Prepare
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    php_version: "{{ php_cli_test_version }}"
+  roles:
+    - role: tborealis.roles.php_repo_sury

--- a/roles/php_cli/molecule/default/vars.yml
+++ b/roles/php_cli/molecule/default/vars.yml
@@ -1,0 +1,5 @@
+---
+# PHP version shared by prepare.yml, converge.yml and verify.yml. 8.3 is
+# shipped by neither bookworm (8.2) nor trixie (8.4), so the packages the
+# role installs can only come from the Sury repo configured in prepare.
+php_cli_test_version: "8.3"

--- a/roles/php_cli/molecule/default/verify.yml
+++ b/roles/php_cli/molecule/default/verify.yml
@@ -1,0 +1,80 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Run php # noqa: command-instead-of-module (functional check that the binary works)
+      ansible.builtin.command: php -v
+      register: php_cli_verify_version
+      changed_when: false
+
+    - name: Assert the configured PHP version is the default CLI
+      ansible.builtin.assert:
+        that:
+          - php_cli_verify_version.stdout is search('^PHP ' ~ php_cli_test_version ~ '\.')
+
+    - name: Probe live ini settings # noqa: command-instead-of-module (proves the templated php.ini is what the interpreter loads)
+      ansible.builtin.command: >-
+        php -r 'echo ini_get("date.timezone"), "\n",
+        ini_get("error_reporting"), "\n", ini_get("error_log");'
+      register: php_cli_verify_ini
+      changed_when: false
+
+    - name: Assert the converge settings are live in the interpreter
+      ansible.builtin.assert:
+        that:
+          - php_cli_verify_ini.stdout_lines[0] == 'Pacific/Auckland'
+          - php_cli_verify_ini.stdout_lines[1] == '32767'
+          - php_cli_verify_ini.stdout_lines[2] == '/var/log/php-cli-molecule.log'
+
+    - name: List loaded modules # noqa: command-instead-of-module (proves the extra package's extension is loaded)
+      ansible.builtin.command: php -m
+      register: php_cli_verify_modules
+      changed_when: false
+
+    - name: Assert the curl extension from php_cli_packages is loaded
+      ansible.builtin.assert:
+        that:
+          - "'curl' in php_cli_verify_modules.stdout_lines"
+
+    - name: Check xdebug is not enabled for the CLI of PHP {{ php_cli_test_version }}
+      ansible.builtin.stat:
+        path: "/etc/php/{{ php_cli_test_version }}/cli/conf.d/20-xdebug.ini"
+      register: php_cli_verify_xdebug_link
+      failed_when: php_cli_verify_xdebug_link.stat.exists
+
+    - name: Stat the xdebug mod shipped by the package for PHP {{ php_cli_test_version }}
+      ansible.builtin.stat:
+        path: "/etc/php/{{ php_cli_test_version }}/mods-available/xdebug.ini"
+      register: php_cli_verify_xdebug_mod
+
+    - name: Assert the xdebug package is installed
+      ansible.builtin.assert:
+        that:
+          - php_cli_verify_xdebug_mod.stat.exists
+
+    - name: Stat the CLI php.ini of PHP {{ php_cli_test_version }}
+      ansible.builtin.stat:
+        path: "/etc/php/{{ php_cli_test_version }}/cli/php.ini"
+      register: php_cli_verify_ini_stat
+
+    - name: Assert php.ini ownership and mode
+      ansible.builtin.assert:
+        that:
+          - php_cli_verify_ini_stat.stat.pw_name == 'root'
+          - php_cli_verify_ini_stat.stat.gr_name == 'root'
+          - php_cli_verify_ini_stat.stat.mode == '0644'
+
+    - name: Read the CLI php.ini of PHP {{ php_cli_test_version }}
+      ansible.builtin.slurp:
+        src: "/etc/php/{{ php_cli_test_version }}/cli/php.ini"
+      register: php_cli_verify_ini_file
+
+    - name: Assert xdebug settings are templated for when xdebug gets enabled
+      ansible.builtin.assert:
+        that:
+          - "'xdebug.client_host = 192.0.2.10' in php_cli_verify_ini_file.content | b64decode"
+          - "'xdebug.idekey = molecule' in php_cli_verify_ini_file.content | b64decode"
+          - "'xdebug.max_nesting_level = 512' in php_cli_verify_ini_file.content | b64decode"

--- a/roles/php_fpm/molecule/default/converge.yml
+++ b/roles/php_fpm/molecule/default/converge.yml
@@ -1,0 +1,22 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    php_version: "{{ php_fpm_test_version }}"
+    php_fpm_date_timezone: Pacific/Auckland
+    php_fpm_memory_limit: 96M
+    php_fpm_max_execution_time: 45
+    php_fpm_post_max_size: 16M
+    php_fpm_upload_max_filesize: 12M
+    php_fpm_opcache_memory_consumption: 64
+    php_fpm_opcache_max_accelerated_files: 20000
+    php_fpm_packages:
+      - "php{{ php_fpm_test_version }}-curl"
+    php_fpm_pools:
+      - src: molecule.conf.j2
+        dest: molecule.conf
+  roles:
+    - role: tborealis.roles.php_fpm

--- a/roles/php_fpm/molecule/default/molecule.yml
+++ b/roles/php_fpm/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/php_fpm/molecule/default/prepare.yml
+++ b/roles/php_fpm/molecule/default/prepare.yml
@@ -1,0 +1,13 @@
+---
+# The role installs php<version>-fpm itself, but that package only exists in
+# the Sury repository; on real hosts php_repo_sury runs earlier in the
+# playbook.
+- name: Prepare
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    php_version: "{{ php_fpm_test_version }}"
+  roles:
+    - role: tborealis.roles.php_repo_sury

--- a/roles/php_fpm/molecule/default/templates/fpm/pools/molecule.conf.j2
+++ b/roles/php_fpm/molecule/default/templates/fpm/pools/molecule.conf.j2
@@ -1,0 +1,11 @@
+; Fixture pool for the molecule scenario.
+[molecule]
+user = www-data
+group = www-data
+listen = {{ php_fpm_test_pool_socket }}
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0660
+pm = static
+pm.max_children = {{ php_fpm_test_pool_max_children }}
+pm.max_requests = 500

--- a/roles/php_fpm/molecule/default/vars.yml
+++ b/roles/php_fpm/molecule/default/vars.yml
@@ -1,0 +1,8 @@
+---
+# Values shared by prepare.yml, converge.yml, verify.yml and the pool
+# fixture template. 8.3 is shipped by neither bookworm (8.2) nor trixie
+# (8.4), so the packages the role installs can only come from the Sury
+# repo configured in prepare.
+php_fpm_test_version: "8.3"
+php_fpm_test_pool_socket: "/run/php/php{{ php_fpm_test_version }}-fpm-molecule.sock"
+php_fpm_test_pool_max_children: 3

--- a/roles/php_fpm/molecule/default/verify.yml
+++ b/roles/php_fpm/molecule/default/verify.yml
@@ -1,0 +1,89 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert the FPM service is running and enabled
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['php' ~ php_fpm_test_version ~ '-fpm.service'].state == 'running'
+          - ansible_facts.services['php' ~ php_fpm_test_version ~ '-fpm.service'].status == 'enabled'
+
+    # The success notice goes to the configured error log, not stderr, so the
+    # command's exit code (the task fails on non-zero rc) is the whole check.
+    - name: Validate the FPM configuration with php-fpm{{ php_fpm_test_version }}
+      ansible.builtin.command: php-fpm{{ php_fpm_test_version }} -t
+      register: php_fpm_verify_configtest
+      changed_when: false
+
+    - name: Count running workers of the molecule pool
+      ansible.builtin.command: "pgrep -fc 'php-fpm: pool molecule'"
+      register: php_fpm_verify_workers
+      changed_when: false
+
+    - name: Assert the static pool spawned the configured number of workers
+      ansible.builtin.assert:
+        that:
+          - php_fpm_verify_workers.stdout | int == php_fpm_test_pool_max_children
+
+    - name: Stat the pool listen socket
+      ansible.builtin.stat:
+        path: "{{ php_fpm_test_pool_socket }}"
+      register: php_fpm_verify_socket
+
+    - name: Assert the pool is listening on its unix socket
+      ansible.builtin.assert:
+        that:
+          - php_fpm_verify_socket.stat.exists
+          - php_fpm_verify_socket.stat.issock
+          - php_fpm_verify_socket.stat.pw_name == 'www-data'
+
+    - name: Stat the installed pool config of PHP {{ php_fpm_test_version }}
+      ansible.builtin.stat:
+        path: "/etc/php/{{ php_fpm_test_version }}/fpm/pool.d/molecule.conf"
+      register: php_fpm_verify_pool_stat
+
+    - name: Assert pool config ownership and mode
+      ansible.builtin.assert:
+        that:
+          - php_fpm_verify_pool_stat.stat.pw_name == 'root'
+          - php_fpm_verify_pool_stat.stat.gr_name == 'root'
+          - php_fpm_verify_pool_stat.stat.mode == '0600'
+
+    - name: Read the installed pool config of PHP {{ php_fpm_test_version }}
+      ansible.builtin.slurp:
+        src: "/etc/php/{{ php_fpm_test_version }}/fpm/pool.d/molecule.conf"
+      register: php_fpm_verify_pool
+
+    - name: Assert the pool fixture values were templated
+      ansible.builtin.assert:
+        that:
+          - "'listen = ' ~ php_fpm_test_pool_socket in php_fpm_verify_pool.content | b64decode"
+          - "'pm.max_children = ' ~ php_fpm_test_pool_max_children in php_fpm_verify_pool.content | b64decode"
+
+    - name: Check the default www pool was removed for PHP {{ php_fpm_test_version }}
+      ansible.builtin.stat:
+        path: "/etc/php/{{ php_fpm_test_version }}/fpm/pool.d/www.conf"
+      register: php_fpm_verify_www_pool
+      failed_when: php_fpm_verify_www_pool.stat.exists
+
+    - name: Read the FPM php.ini of PHP {{ php_fpm_test_version }}
+      ansible.builtin.slurp:
+        src: "/etc/php/{{ php_fpm_test_version }}/fpm/php.ini"
+      register: php_fpm_verify_ini
+
+    - name: Assert the converge ini settings were templated
+      ansible.builtin.assert:
+        that:
+          - "'memory_limit = 96M' in php_fpm_verify_ini.content | b64decode"
+          - "'max_execution_time = 45' in php_fpm_verify_ini.content | b64decode"
+          - "'post_max_size = 16M' in php_fpm_verify_ini.content | b64decode"
+          - "'upload_max_filesize = 12M' in php_fpm_verify_ini.content | b64decode"
+          - "'date.timezone = \"Pacific/Auckland\"' in php_fpm_verify_ini.content | b64decode"
+          - "'opcache.memory_consumption = 64' in php_fpm_verify_ini.content | b64decode"
+          - "'opcache.max_accelerated_files = 20000' in php_fpm_verify_ini.content | b64decode"

--- a/roles/phpbu/defaults/main.yml
+++ b/roles/phpbu/defaults/main.yml
@@ -1,10 +1,12 @@
 ---
 phpbu_enable: true
 
-phpbu_phar_url: "https://phar.phpbu.de/phpbu-6.0.23.phar"
+# GitHub is the canonical source; the phar.phpbu.de/schema.phpbu.de mirrors
+# are dead (TLS failure / NXDOMAIN). Same artifact: the checksum is unchanged.
+phpbu_phar_url: "https://github.com/sebastianfeldmann/phpbu/releases/download/6.0.23/phpbu.phar"
 phpbu_phar_checksum: "sha256:eea9071fb40063b5aaaf37e8ef5c492cef141c6ef1b37fd28de9d236ca38a858"
 
-phpbu_schema_url: "https://schema.phpbu.de/6.0/phpbu.xsd"
+phpbu_schema_url: "https://raw.githubusercontent.com/sebastianfeldmann/phpbu/6.0.23/phpbu.xsd"
 
 phpbu_cron_enable: true
 

--- a/roles/phpbu/molecule/default/converge.yml
+++ b/roles/phpbu/molecule/default/converge.yml
@@ -1,0 +1,11 @@
+---
+# The role templates the consumer-supplied playbook file
+# templates/phpbu/phpbu.xml (this scenario ships a tar-backup fixture) and
+# requires phpbu_cron_time to be set — it has no default.
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  roles:
+    - role: tborealis.roles.phpbu

--- a/roles/phpbu/molecule/default/molecule.yml
+++ b/roles/phpbu/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/phpbu/molecule/default/prepare.yml
+++ b/roles/phpbu/molecule/default/prepare.yml
@@ -1,0 +1,19 @@
+---
+# phpbu is a PHP phar (needs a CLI plus ext-dom to parse its XML config) and
+# installs a crontab entry (needs the cron package), but installing PHP and
+# cron is outside the role's contract — real playbooks apply php_repo_sury /
+# php_cli and get cron from the OS install. Mirror that order here.
+- name: Prepare
+  hosts: all
+  become: true
+  roles:
+    - role: tborealis.roles.php_repo_sury
+  tasks:
+    - name: Install PHP CLI and cron
+      ansible.builtin.apt:
+        pkg:
+          - php8.3-cli
+          - php8.3-xml
+          - php8.3-mbstring
+          - cron
+        state: present

--- a/roles/phpbu/molecule/default/templates/phpbu/phpbu.xml
+++ b/roles/phpbu/molecule/default/templates/phpbu/phpbu.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpbu xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="{{ phpbu_lib_dir }}/phpbu.xsd">
+  <backups>
+    <backup name="molecule-fixture">
+      <source type="tar">
+        <option name="path" value="/etc/skel"/>
+      </source>
+      <target dirname="{{ phpbu_backup_dir }}" filename="molecule-%Y%m%d.tar"/>
+    </backup>
+  </backups>
+</phpbu>

--- a/roles/phpbu/molecule/default/vars.yml
+++ b/roles/phpbu/molecule/default/vars.yml
@@ -1,0 +1,7 @@
+---
+# Fixture values shared by converge.yml and verify.yml. The "private key" is
+# base64 of a plain throwaway sentence — deliberately not shaped like real key
+# material so secret scanning cannot mistake it (the role only b64decodes it
+# into a file; content is never parsed).
+phpbu_cron_time: ["30", "2", "*", "*", "*"]
+phpbu_private_key: bW9sZWN1bGUgdGhyb3dhd2F5IGtleSBtYXRlcmlhbCAtIG5vdCBhIHJlYWwga2V5Cg==

--- a/roles/phpbu/molecule/default/verify.yml
+++ b/roles/phpbu/molecule/default/verify.yml
@@ -1,0 +1,84 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Run phpbu
+      ansible.builtin.command: /usr/local/bin/phpbu --version
+      register: phpbu_verify_version
+      changed_when: false
+
+    - name: Assert the pinned phpbu version is installed
+      ansible.builtin.assert:
+        that:
+          - "'phpbu 6.0.23' in phpbu_verify_version.stdout"
+
+    - name: Stat the config file
+      ansible.builtin.stat:
+        path: /etc/phpbu.xml
+      register: phpbu_verify_config_stat
+
+    - name: Assert the config is root-owned and group-readable by phpbu only
+      ansible.builtin.assert:
+        that:
+          - phpbu_verify_config_stat.stat.pw_name == 'root'
+          - phpbu_verify_config_stat.stat.gr_name == 'phpbu'
+          - phpbu_verify_config_stat.stat.mode == '0640'
+
+    - name: Read the config file
+      ansible.builtin.slurp:
+        src: /etc/phpbu.xml
+      register: phpbu_verify_config
+
+    - name: Assert the fixture backup is configured
+      ansible.builtin.assert:
+        that:
+          - "'<backup name=\"molecule-fixture\">' in phpbu_verify_config.content | b64decode"
+          - "'dirname=\"/var/lib/phpbu/backups\"' in phpbu_verify_config.content | b64decode"
+
+    - name: Stat the deployed private key
+      ansible.builtin.stat:
+        path: /home/phpbu/.ssh/id_ed25519
+      register: phpbu_verify_key
+
+    - name: Assert the private key is in place and only readable by phpbu
+      ansible.builtin.assert:
+        that:
+          - phpbu_verify_key.stat.exists
+          - phpbu_verify_key.stat.pw_name == 'phpbu'
+          - phpbu_verify_key.stat.mode == '0600'
+
+    - name: Read the phpbu user's crontab
+      ansible.builtin.command: crontab -l -u phpbu
+      register: phpbu_verify_crontab
+      changed_when: false
+
+    - name: Assert the backup cron entry is installed
+      ansible.builtin.assert:
+        that:
+          - "'#Ansible: PHPBU Database Backup' in phpbu_verify_crontab.stdout"
+          - >-
+            (phpbu_cron_time | join(' ') ~
+            ' /usr/local/bin/phpbu --configuration=/etc/phpbu.xml')
+            in phpbu_verify_crontab.stdout
+
+    - name: Run a real backup as the phpbu user
+      ansible.builtin.command: /usr/local/bin/phpbu --configuration=/etc/phpbu.xml -v
+      become: true
+      become_user: phpbu
+      register: phpbu_verify_run
+      changed_when: false
+
+    - name: Find the created backup archive
+      ansible.builtin.find:
+        paths: /var/lib/phpbu/backups
+        patterns: molecule-*.tar
+      register: phpbu_verify_backup
+
+    - name: Assert a non-empty backup archive was created
+      ansible.builtin.assert:
+        that:
+          - phpbu_verify_backup.files | length > 0
+          - phpbu_verify_backup.files[0].size > 0

--- a/roles/symfony_params/molecule/default/converge.yml
+++ b/roles/symfony_params/molecule/default/converge.yml
@@ -1,0 +1,13 @@
+---
+# The role no-ops unless symfony_params_template is set, so converge provides
+# realistic test values. The role resolves the template relative to the
+# playbook, so the fixture lives in templates/symfony-params/ here.
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    symfony_params_template: parameters.yaml.j2
+  roles:
+    - role: tborealis.roles.symfony_params

--- a/roles/symfony_params/molecule/default/molecule.yml
+++ b/roles/symfony_params/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/symfony_params/molecule/default/templates/symfony-params/parameters.yaml.j2
+++ b/roles/symfony_params/molecule/default/templates/symfony-params/parameters.yaml.j2
@@ -1,0 +1,6 @@
+parameters:
+    database_host: "{{ symfony_params_database_host }}"
+    database_port: 3306
+    database_name: molecule_app
+    database_password: "{{ symfony_params_database_password }}"
+    secret: "{{ symfony_params_app_secret }}"

--- a/roles/symfony_params/molecule/default/vars.yml
+++ b/roles/symfony_params/molecule/default/vars.yml
@@ -1,0 +1,9 @@
+---
+# Test values shared by converge.yml and verify.yml. Secrets are throwaway
+# with a realistic shape, never real ones.
+symfony_params_file_path: /var/www/molecule-app/config
+symfony_params_file_user: www-data
+symfony_params_file_group: www-data
+symfony_params_database_host: db.molecule.internal
+symfony_params_database_password: molecule-Db-Passw0rd1
+symfony_params_app_secret: 5f4dcc3b5aa765d61d8327deb882cf99molecule

--- a/roles/symfony_params/molecule/default/verify.yml
+++ b/roles/symfony_params/molecule/default/verify.yml
@@ -1,0 +1,47 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Stat the params directory
+      ansible.builtin.stat:
+        path: "{{ symfony_params_file_path }}"
+      register: symfony_params_verify_dir
+
+    - name: Assert directory ownership and mode
+      ansible.builtin.assert:
+        that:
+          - symfony_params_verify_dir.stat.isdir
+          - symfony_params_verify_dir.stat.pw_name == symfony_params_file_user
+          - symfony_params_verify_dir.stat.gr_name == symfony_params_file_group
+          - symfony_params_verify_dir.stat.mode == '0750'
+
+    - name: Stat the parameters file
+      ansible.builtin.stat:
+        path: "{{ symfony_params_file_path }}/parameters.yaml"
+      register: symfony_params_verify_file
+
+    - name: Assert file ownership and mode
+      ansible.builtin.assert:
+        that:
+          - symfony_params_verify_file.stat.exists
+          - symfony_params_verify_file.stat.pw_name == symfony_params_file_user
+          - symfony_params_verify_file.stat.gr_name == symfony_params_file_group
+          - symfony_params_verify_file.stat.mode == '0640'
+
+    - name: Read the parameters file
+      ansible.builtin.slurp:
+        src: "{{ symfony_params_file_path }}/parameters.yaml"
+      register: symfony_params_verify_content
+
+    - name: Assert the rendered file parses as YAML with the converge values
+      vars:
+        symfony_params_verify_params: >-
+          {{ (symfony_params_verify_content.content | b64decode | from_yaml).parameters }}
+      ansible.builtin.assert:
+        that:
+          - symfony_params_verify_params.database_host == symfony_params_database_host
+          - symfony_params_verify_params.database_password == symfony_params_database_password
+          - symfony_params_verify_params.secret == symfony_params_app_secret


### PR DESCRIPTION
## Summary

Batch 3 of the testing rollout: Molecule scenarios for **php_cli**, **php_fpm**, **composer**, **phpbu**, **new_relic**, and **symfony_params**. All six pass converge → idempotence → verify on bookworm and trixie locally.

### Bugs found and fixed

- **composer**: `composer_global_packages` never worked — the composer module rejects arguments embedded in the command string (`command: 'global require "pkg=ver"'`). Now uses the `arguments` + `global_command` parameters.
- **phpbu**: the role could not converge anywhere — `phar.phpbu.de` fails its TLS handshake and `schema.phpbu.de` no longer resolves. Both URLs now point at GitHub (same pinned version; the phar checksum is byte-identical).

### Scenario highlights

- php_cli/php_fpm: PHP 8.3 from Sury (proves the repo — neither release ships 8.3); live `ini_get()` probes, running pool worker count, socket checks, `php-fpm -t`
- composer: installs phpstan globally and runs it
- phpbu: runs a **real backup** as the phpbu user and asserts the archive, plus cron entry and deploy-key permissions
- new_relic: dummy licence key; asserts package, repo source, rendered ini (the scenario supplies the `Restart php-fpm` handler the role expects from php_fpm)
- symfony_params: parses the rendered YAML and asserts values/ownership/modes

### Pre-existing issues noticed but not fixed (tracked for an end-of-rollout report)

- new_relic notifies a handler it doesn't ship (`Restart php-fpm` lives in php_fpm); `newrelic_enable` is a dead variable
- phpbu has no default for `phpbu_cron_time` (role errors on stock defaults); both `get_url` tasks force re-download every run
- Several roles require playbook-relative template fixtures (`templates/<role>/...`) — an undocumented consumer contract