### PR TITLE
Add molecule scenarios for the data service roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
   `certbot`, and `php_repo_sury`.
 - **meta:** Molecule scenarios for the PHP stack roles: `php_cli`, `php_fpm`,
   `composer`, `phpbu`, `new_relic`, and `symfony_params`.
+- **meta:** Molecule scenarios for the data service roles: `pgsql`, `pgsql_client`,
+  `redis`, `rabbitmq` (bookworm only), `supervisor`, and `mailhog`.
 
 ### Fixed
 

--- a/roles/mailhog/molecule/default/converge.yml
+++ b/roles/mailhog/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: tborealis.roles.mailhog

--- a/roles/mailhog/molecule/default/molecule.yml
+++ b/roles/mailhog/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/mailhog/molecule/default/verify.yml
+++ b/roles/mailhog/molecule/default/verify.yml
@@ -1,0 +1,65 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars:
+    mailhog_verify_subject: molecule-round-trip-test
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert mailhog service is running
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['mailhog.service'].state == 'running'
+
+    - name: Wait for the SMTP port to accept connections
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 1025
+        timeout: 30
+
+    - name: Request the web UI
+      ansible.builtin.uri:
+        url: http://127.0.0.1:8025/
+        return_content: true
+      register: mailhog_verify_ui
+
+    - name: Assert the web UI serves MailHog
+      ansible.builtin.assert:
+        that:
+          - mailhog_verify_ui.status == 200
+          - "'MailHog' in mailhog_verify_ui.content"
+
+    - name: Send a test mail through the SMTP port
+      community.general.mail:
+        host: 127.0.0.1
+        port: 1025
+        secure: never
+        from: molecule@example.com
+        to: inbox@example.com
+        subject: "{{ mailhog_verify_subject }}"
+        body: Functional SMTP round-trip sent by molecule verify.
+
+    - name: Query the messages API
+      ansible.builtin.uri:
+        url: http://127.0.0.1:8025/api/v2/messages
+        return_content: true
+      register: mailhog_verify_messages
+
+    - name: Assert the test mail was captured
+      ansible.builtin.assert:
+        that:
+          - mailhog_verify_messages.json.total | int >= 1
+          - mailhog_verify_subject in mailhog_verify_messages.json['items'][0].Content.Headers.Subject[0]
+
+    - name: Read the systemd unit
+      ansible.builtin.slurp:
+        src: /lib/systemd/system/mailhog.service
+      register: mailhog_verify_unit
+
+    - name: Assert the unit runs the installed binary as the mailhog user
+      ansible.builtin.assert:
+        that:
+          - "'ExecStart=/opt/mailhog/mailhog' in mailhog_verify_unit.content | b64decode"
+          - "'User=mailhog' in mailhog_verify_unit.content | b64decode"

--- a/roles/pgsql/molecule/default/converge.yml
+++ b/roles/pgsql/molecule/default/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    # Non-default tuning values so verify can assert the templates took them.
+    postgres_max_connections: 50
+    postgres_shared_buffers: 128MB
+    postgres_effective_cache_size: 512MB
+    postgres_max_wal_size: 2GB
+    postgres_databases:
+      - molecule_db
+    postgres_users:
+      - user: molecule_user
+        password: "{{ postgres_molecule_user_password }}"
+  roles:
+    - role: tborealis.roles.pgsql

--- a/roles/pgsql/molecule/default/molecule.yml
+++ b/roles/pgsql/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/pgsql/molecule/default/prepare.yml
+++ b/roles/pgsql/molecule/default/prepare.yml
@@ -1,0 +1,15 @@
+---
+# The role runs its database tasks with become_user postgres; unprivileged
+# become needs setfacl to hand module temp files to that user, and the role's
+# locale_gen task needs /etc/locale.gen. Real hosts get both packages (acl,
+# locales) from the base role.
+- name: Prepare
+  hosts: all
+  become: true
+  tasks:
+    - name: Install base-role prerequisites
+      ansible.builtin.apt:
+        pkg:
+          - acl
+          - locales
+        state: present

--- a/roles/pgsql/molecule/default/vars.yml
+++ b/roles/pgsql/molecule/default/vars.yml
@@ -1,0 +1,7 @@
+---
+# Values shared by converge.yml and verify.yml. Throwaway test credentials
+# with a realistic shape, never real ones.
+# The role has no default for postgres_version and only ships config templates
+# for 12, 13 and 15; PGDG publishes 15 for both bookworm and trixie.
+postgres_version: 15
+postgres_molecule_user_password: molecule-Pgsql-Passw0rd1

--- a/roles/pgsql/molecule/default/verify.yml
+++ b/roles/pgsql/molecule/default/verify.yml
@@ -1,0 +1,76 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert the PostgreSQL cluster service is running
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['postgresql@' ~ postgres_version ~ '-main.service'].state == 'running'
+
+    - name: Query the server version as the postgres superuser
+      become: true
+      become_user: postgres
+      community.postgresql.postgresql_query:
+        query: SHOW server_version
+      register: pgsql_verify_version
+
+    - name: Assert the requested major version is running
+      ansible.builtin.assert:
+        that:
+          - pgsql_verify_version.query_result[0].server_version.split('.')[0] == postgres_version | string
+
+    - name: Log in as the created user over TCP and query the created database
+      community.postgresql.postgresql_query:
+        login_host: 127.0.0.1
+        login_user: molecule_user
+        login_password: "{{ postgres_molecule_user_password }}"
+        login_db: molecule_db
+        query: SELECT current_database() AS db
+      register: pgsql_verify_login
+
+    - name: Assert the TCP login reached the created database
+      ansible.builtin.assert:
+        that:
+          - pgsql_verify_login.query_result[0].db == 'molecule_db'
+
+    - name: Read postgresql.conf
+      ansible.builtin.slurp:
+        src: /etc/postgresql/{{ postgres_version }}/main/postgresql.conf
+      register: pgsql_verify_conf
+
+    - name: Assert tuning values from converge are templated
+      ansible.builtin.assert:
+        that:
+          - "'max_connections = 50' in pgsql_verify_conf.content | b64decode"
+          - "'shared_buffers = 128MB' in pgsql_verify_conf.content | b64decode"
+          - "'effective_cache_size = 512MB' in pgsql_verify_conf.content | b64decode"
+          - "'max_wal_size = 2GB' in pgsql_verify_conf.content | b64decode"
+          - "'fsync = on' in pgsql_verify_conf.content | b64decode"
+
+    - name: Stat pg_hba.conf
+      ansible.builtin.stat:
+        path: /etc/postgresql/{{ postgres_version }}/main/pg_hba.conf
+      register: pgsql_verify_hba
+
+    - name: Assert pg_hba.conf ownership and mode
+      ansible.builtin.assert:
+        that:
+          - pgsql_verify_hba.stat.pw_name == 'postgres'
+          - pgsql_verify_hba.stat.gr_name == 'postgres'
+          - pgsql_verify_hba.stat.mode == '0640'
+
+    - name: Read pg_hba.conf
+      ansible.builtin.slurp:
+        src: /etc/postgresql/{{ postgres_version }}/main/pg_hba.conf
+      register: pgsql_verify_hba_content
+
+    - name: Assert TCP connections require scram-sha-256
+      ansible.builtin.assert:
+        that:
+          - "'host    all             all             127.0.0.1/32            scram-sha-256' in pgsql_verify_hba_content.content | b64decode"

--- a/roles/pgsql_client/molecule/default/converge.yml
+++ b/roles/pgsql_client/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  roles:
+    - role: tborealis.roles.pgsql_client

--- a/roles/pgsql_client/molecule/default/molecule.yml
+++ b/roles/pgsql_client/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/pgsql_client/molecule/default/vars.yml
+++ b/roles/pgsql_client/molecule/default/vars.yml
@@ -1,0 +1,5 @@
+---
+# Values shared by converge.yml and verify.yml.
+# The role has no default for postgres_version; PGDG publishes 15 for both
+# bookworm and trixie.
+postgres_version: 15

--- a/roles/pgsql_client/molecule/default/verify.yml
+++ b/roles/pgsql_client/molecule/default/verify.yml
@@ -1,0 +1,36 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Run psql # noqa: command-instead-of-module (functional check that the binary works)
+      ansible.builtin.command: psql --version
+      changed_when: false
+      register: pgsql_client_verify_psql
+
+    - name: Assert psql is the requested major version
+      ansible.builtin.assert:
+        that:
+          - pgsql_client_verify_psql.stdout is search('^psql \(PostgreSQL\) ' ~ postgres_version ~ '\.')
+
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+
+    - name: Assert the client package was installed from the PGDG repository
+      ansible.builtin.assert:
+        that:
+          - "'pgdg' in ansible_facts.packages['postgresql-client-' ~ postgres_version][0].version"
+
+    - name: Read the PGDG apt source
+      ansible.builtin.slurp:
+        src: /etc/apt/sources.list.d/postgresql.sources
+      register: pgsql_client_verify_source
+
+    - name: Assert the PGDG source targets this release and the shared keyring
+      ansible.builtin.assert:
+        that:
+          - "'URIs: https://apt.postgresql.org/pub/repos/apt/' in pgsql_client_verify_source.content | b64decode"
+          - "'Signed-By: /etc/apt/keyrings/postgresql.gpg' in pgsql_client_verify_source.content | b64decode"
+          - (ansible_facts['distribution_release'] ~ '-pgdg') in pgsql_client_verify_source.content | b64decode

--- a/roles/rabbitmq/molecule/default/converge.yml
+++ b/roles/rabbitmq/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  roles:
+    - role: tborealis.roles.rabbitmq

--- a/roles/rabbitmq/molecule/default/molecule.yml
+++ b/roles/rabbitmq/molecule/default/molecule.yml
@@ -1,0 +1,18 @@
+---
+# Inherits from .config/molecule/config.yml, except `platforms:` (lists
+# replace on merge), which is redefined here with the bookworm entry only:
+# trixie's apt rejects the upstream RabbitMQ signing key (SHA1 binding).
+# The restriction is mirrored in .config/molecule/platforms.yml for CI.
+platforms:
+  - name: bookworm
+    image: ${MOLECULE_IMAGE_REPO:-ghcr.io/tborealis/ansible-roles}/molecule-debian:bookworm
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    cgroupns_mode: host
+    privileged: false
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp

--- a/roles/rabbitmq/molecule/default/vars.yml
+++ b/roles/rabbitmq/molecule/default/vars.yml
@@ -1,0 +1,3 @@
+---
+# Throwaway test password shared by converge.yml and verify.yml.
+rabbitmq_admin_password: molecule-Rabbit-Passw0rd1

--- a/roles/rabbitmq/molecule/default/verify.yml
+++ b/roles/rabbitmq/molecule/default/verify.yml
@@ -1,0 +1,65 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert RabbitMQ service is running
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['rabbitmq-server.service'].state == 'running'
+
+    - name: Check broker status
+      ansible.builtin.command: rabbitmqctl status
+      register: rabbitmq_verify_status
+      changed_when: false
+
+    - name: List users
+      ansible.builtin.command: rabbitmqctl list_users
+      register: rabbitmq_verify_users
+      changed_when: false
+
+    - name: Assert admin user exists and guest user is removed
+      ansible.builtin.assert:
+        that:
+          - "'admin' in rabbitmq_verify_users.stdout"
+          - "'guest' not in rabbitmq_verify_users.stdout"
+
+    - name: List permissions on the default vhost
+      ansible.builtin.command: rabbitmqctl list_permissions -p /
+      register: rabbitmq_verify_permissions
+      changed_when: false
+
+    - name: Assert admin has full permissions on the default vhost
+      ansible.builtin.assert:
+        that:
+          - "'admin' in rabbitmq_verify_permissions.stdout"
+
+    - name: Log in to the management API as the admin user
+      ansible.builtin.uri:
+        url: http://127.0.0.1:15672/api/whoami
+        user: admin
+        password: "{{ rabbitmq_admin_password }}"
+        force_basic_auth: true
+        return_content: true
+      register: rabbitmq_verify_whoami
+
+    - name: Assert the admin user authenticates with the administrator tag
+      ansible.builtin.assert:
+        that:
+          - rabbitmq_verify_whoami.json.name == 'admin'
+          - "'administrator' in rabbitmq_verify_whoami.json.tags"
+
+    - name: Read Erlang apt pin
+      ansible.builtin.slurp:
+        src: /etc/apt/preferences.d/rabbitmq-erlang.pref
+      register: rabbitmq_verify_erlang_pref
+
+    - name: Assert upstream Erlang packages are pinned
+      ansible.builtin.assert:
+        that:
+          - "'Pin: origin deb1.rabbitmq.com' in rabbitmq_verify_erlang_pref.content | b64decode"

--- a/roles/redis/molecule/default/converge.yml
+++ b/roles/redis/molecule/default/converge.yml
@@ -1,0 +1,13 @@
+---
+# redis_overcommit_memory stays at its default (false): sysctl writes fail
+# in unprivileged containers.
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    redis_maxmemory: 64mb
+    redis_maxmemory_policy: allkeys-lru
+  roles:
+    - role: tborealis.roles.redis

--- a/roles/redis/molecule/default/molecule.yml
+++ b/roles/redis/molecule/default/molecule.yml
@@ -1,0 +1,29 @@
+---
+# Overrides the base platforms (lists replace): trixie's redis-server unit
+# requests CAP_SYS_ADMIN via AmbientCapabilities, which unprivileged
+# containers cannot grant, so these containers run privileged.
+platforms:
+  - name: bookworm
+    image: ${MOLECULE_IMAGE_REPO:-ghcr.io/tborealis/ansible-roles}/molecule-debian:bookworm
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    cgroupns_mode: host
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+  - name: trixie
+    image: ${MOLECULE_IMAGE_REPO:-ghcr.io/tborealis/ansible-roles}/molecule-debian:trixie
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    cgroupns_mode: host
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp

--- a/roles/redis/molecule/default/vars.yml
+++ b/roles/redis/molecule/default/vars.yml
@@ -1,0 +1,3 @@
+---
+# Throwaway test password shared by converge.yml and verify.yml.
+redis_password: molecule-Redis-Passw0rd1

--- a/roles/redis/molecule/default/verify.yml
+++ b/roles/redis/molecule/default/verify.yml
@@ -1,0 +1,67 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert Redis service is running
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['redis-server.service'].state == 'running'
+
+    - name: Ping Redis without authentication
+      ansible.builtin.command: redis-cli ping
+      register: redis_verify_unauth_ping
+      changed_when: false
+      failed_when: false
+
+    - name: Assert unauthenticated clients are rejected
+      ansible.builtin.assert:
+        that:
+          - "'PONG' not in redis_verify_unauth_ping.stdout"
+          - >-
+            'NOAUTH' in redis_verify_unauth_ping.stdout
+            or 'NOAUTH' in redis_verify_unauth_ping.stderr
+
+    - name: Ping Redis with the configured password
+      ansible.builtin.command: >-
+        redis-cli -a {{ redis_password }} --no-auth-warning ping
+      register: redis_verify_auth_ping
+      changed_when: false
+
+    - name: Assert authenticated ping returns PONG
+      ansible.builtin.assert:
+        that:
+          - redis_verify_auth_ping.stdout == 'PONG'
+
+    - name: Read managed Redis config
+      ansible.builtin.slurp:
+        src: /etc/redis/redis-ansible.conf
+      register: redis_verify_conf
+
+    - name: Assert converge values are present in the managed config
+      ansible.builtin.assert:
+        that:
+          - "'maxmemory 64mb' in redis_verify_conf.content | b64decode"
+          - "'maxmemory-policy allkeys-lru' in redis_verify_conf.content | b64decode"
+          - "'requirepass ' ~ redis_password in redis_verify_conf.content | b64decode"
+
+    - name: Read packaged Redis config
+      ansible.builtin.slurp:
+        src: /etc/redis/redis.conf
+      register: redis_verify_main_conf
+
+    - name: Assert the managed config is included by the packaged config
+      ansible.builtin.assert:
+        that:
+          - "'include /etc/redis/redis-ansible.conf' in redis_verify_main_conf.content | b64decode"
+
+    - name: Check no apt version pin is left when redis_version is unset
+      ansible.builtin.stat:
+        path: /etc/apt/preferences.d/redis.pref
+      register: redis_verify_pin
+      failed_when: redis_verify_pin.stat.exists

--- a/roles/supervisor/molecule/default/converge.yml
+++ b/roles/supervisor/molecule/default/converge.yml
@@ -1,0 +1,12 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    supervisor_configs:
+      - template: sleeper.conf.j2
+        dest: sleeper.conf
+    supervisor_users:
+      - root
+  roles:
+    - role: tborealis.roles.supervisor

--- a/roles/supervisor/molecule/default/molecule.yml
+++ b/roles/supervisor/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/supervisor/molecule/default/templates/supervisor/sleeper.conf.j2
+++ b/roles/supervisor/molecule/default/templates/supervisor/sleeper.conf.j2
@@ -1,0 +1,7 @@
+; Molecule test fixture: a trivial long-running program.
+[program:sleeper]
+command=/bin/sleep infinity
+autostart=true
+autorestart=true
+redirect_stderr=true
+stdout_logfile=/var/log/supervisor/sleeper.log

--- a/roles/supervisor/molecule/default/verify.yml
+++ b/roles/supervisor/molecule/default/verify.yml
@@ -1,0 +1,52 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert supervisor service is running
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['supervisor.service'].state == 'running'
+
+    - name: Query the test program status # noqa: command-instead-of-module (exercises supervisorctl against the live daemon)
+      ansible.builtin.command: supervisorctl status sleeper
+      register: supervisor_verify_status
+      changed_when: false
+
+    - name: Assert the test program is running under supervisor
+      ansible.builtin.assert:
+        that:
+          - "'RUNNING' in supervisor_verify_status.stdout"
+
+    - name: Read supervisord.conf
+      ansible.builtin.slurp:
+        src: /etc/supervisor/supervisord.conf
+      register: supervisor_verify_conf
+
+    - name: Assert the control socket is owned by the supervisor group
+      ansible.builtin.assert:
+        that:
+          - "'chown=root:supervisor' in supervisor_verify_conf.content | b64decode"
+
+    - name: Read the installed program config
+      ansible.builtin.slurp:
+        src: /etc/supervisor/conf.d/sleeper.conf
+      register: supervisor_verify_program
+
+    - name: Assert the program config was rendered from the fixture
+      ansible.builtin.assert:
+        that:
+          - "'command=/bin/sleep infinity' in supervisor_verify_program.content | b64decode"
+
+    - name: Look up the supervisor group
+      ansible.builtin.getent:
+        database: group
+        key: supervisor
+
+    - name: Assert root was added to the supervisor group
+      ansible.builtin.assert:
+        that:
+          - "'root' in ansible_facts.getent_group['supervisor'][2]"


### PR DESCRIPTION
## Summary

Batch 4 of the testing rollout: Molecule scenarios for **pgsql**, **pgsql_client**, **redis**, **rabbitmq**, **supervisor**, and **mailhog**. All pass converge → idempotence → verify locally (rabbitmq on bookworm only — trixie's apt rejects the upstream key, as already recorded in `platforms.yml`).

### Scenario highlights

- pgsql: PG15 with a test database/user and tuning overrides; verifies a superuser query, **a TCP login as the created user against the created database**, and postgresql.conf/pg_hba.conf content
- redis: requires **privileged containers** — trixie's redis-server unit requests `CAP_SYS_ADMIN`, which unprivileged containers can't grant; the scenario overrides the platform list (first use of that mechanism). Verifies authenticated and unauthenticated `redis-cli ping` and rendered config; `redis_overcommit_memory` stays false (sysctl is impossible in containers)
- rabbitmq: `rabbitmqctl` status/users plus a real management-API login as the created admin
- mailhog: full SMTP round-trip — sends through port 1025 and asserts the message in the API (the mail module MIME-encodes headers, hence a contains-match)
- supervisor: fixture program asserted RUNNING via supervisorctl

### Pre-existing issues noticed but not fixed (tracked for the end-of-rollout report)

- mailhog: unguarded binary download (no checksum), amd64-only, unit file installed 0755, and upstream MailHog is archived/unmaintained
- pgsql: `postgres_version` is required but undocumented; removal task files unreachable from main.yml; the restart handler in handlers/ is dead code
- supervisor/rabbitmq: rely on Debian's start-on-install; no explicit enable/start task