### PR TITLE
Add molecule scenarios for the tooling roles

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,3 +6,6 @@ skip_list:
 kinds:
   # Shared molecule scenario values, not playbooks (see docs/testing.md)
   - vars: "**/molecule/*/vars.yml"
+exclude_paths:
+  # Agent worktrees and session tooling, not part of the collection
+  - .claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,19 @@ flagged with **BREAKING** and require a MAJOR version bump.
   `composer`, `phpbu`, `new_relic`, and `symfony_params`.
 - **meta:** Molecule scenarios for the data service roles: `pgsql`, `pgsql_client`,
   `redis`, `rabbitmq` (bookworm only), `supervisor`, and `mailhog`.
+- **meta:** Molecule scenarios for the tooling roles: `node`, `nvm`, `yarn`, `chrome`,
+  `stripe_cli`, and `gpg`.
 
 ### Fixed
+
+- **nvm:** version installs and the default alias reported changed on every run; they
+  now detect the existing state. The installer's `creates:` guard checked the wrong
+  user's home directory (and would have blocked nvm upgrades); the version check
+  alone now guards it.
+- **stripe_cli:** the version check probed `/usr/local/bin/stripe`, but the package
+  installs `/usr/bin/stripe`, so the deb was re-downloaded on every run.
+- **chrome:** `unzip` joined `chrome_system_dependencies` — `@puppeteer/browsers`
+  cannot extract the chrome archive without it.
 
 - **apache2:** the `apache2_env_vars` default was a list, which broke the role's own
   envvars template (it iterates `.items()`); the default is now `{}`.

--- a/roles/chrome/defaults/main.yml
+++ b/roles/chrome/defaults/main.yml
@@ -6,6 +6,7 @@ chrome_remove_system_chrome: false
 
 # See https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/debian/dist_package_versions.json
 chrome_system_dependencies:
+  - unzip # @puppeteer/browsers needs it to extract the chrome archive
   - libasound2
   - libatk-bridge2.0-0
   - libatk1.0-0

--- a/roles/chrome/molecule/default/converge.yml
+++ b/roles/chrome/molecule/default/converge.yml
@@ -1,0 +1,9 @@
+---
+# Defaults install the current Chrome stable, which is the real contract.
+# chrome_install_chromedriver stays at its default (false) to keep the
+# scenario to one ~150 MB browser download.
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: tborealis.roles.chrome

--- a/roles/chrome/molecule/default/molecule.yml
+++ b/roles/chrome/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/chrome/molecule/default/prepare.yml
+++ b/roles/chrome/molecule/default/prepare.yml
@@ -1,0 +1,11 @@
+---
+# The role installs Chrome with `npx @puppeteer/browsers` but does not
+# install Node.js itself. Real playbooks apply the node role first, so
+# mirror that here.
+- name: Prepare
+  hosts: all
+  become: true
+  vars:
+    node_version: 22
+  roles:
+    - role: tborealis.roles.node

--- a/roles/chrome/molecule/default/verify.yml
+++ b/roles/chrome/molecule/default/verify.yml
@@ -1,0 +1,37 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+    - name: Stat the google-chrome link
+      ansible.builtin.stat:
+        path: /usr/local/bin/google-chrome
+      register: chrome_verify_link
+
+    - name: Assert chrome is linked into the puppeteer install path
+      ansible.builtin.assert:
+        that:
+          - chrome_verify_link.stat.islnk
+          - chrome_verify_link.stat.lnk_source is match('/opt/chrome/')
+
+    - name: Check the chrome version
+      ansible.builtin.command: /usr/local/bin/google-chrome --version --no-sandbox
+      register: chrome_verify_version
+      changed_when: false
+
+    - name: Assert chrome reports a version string
+      ansible.builtin.assert:
+        that:
+          - chrome_verify_version.stdout is search('Google Chrome[A-Za-z ]* \d+\.\d+\.\d+\.\d+')
+
+    - name: Render a page headless
+      ansible.builtin.command: >-
+        /usr/local/bin/google-chrome --headless --no-sandbox
+        --disable-dev-shm-usage --disable-gpu --dump-dom about:blank
+      register: chrome_verify_headless
+      changed_when: false
+
+    - name: Assert headless chrome rendered the page
+      ansible.builtin.assert:
+        that:
+          - "'<html>' in chrome_verify_headless.stdout"

--- a/roles/gpg/molecule/default/converge.yml
+++ b/roles/gpg/molecule/default/converge.yml
@@ -1,0 +1,43 @@
+---
+# The role no-ops with default variables, so feed it the fixture keys staged
+# by prepare.yml: a passphrase-protected private key plus an ultimately
+# trusted public key for a regular user. slurp returns file content base64
+# encoded, which is exactly the shape gpg_config expects for `key`.
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    gpg_config:
+      - user: "{{ gpg_test_user }}"
+        private_keys:
+          - id: "{{ gpg_converge_private_fpr.content | b64decode | trim }}"
+            key: "{{ gpg_converge_private_key.content }}"
+            passphrase: "{{ gpg_test_passphrase }}"
+        public_keys:
+          - id: "{{ gpg_converge_public_fpr.content | b64decode | trim }}"
+            key: "{{ gpg_converge_public_key.content }}"
+            owner_trust_level: 5
+  pre_tasks:
+    - name: Read the staged private key fingerprint
+      ansible.builtin.slurp:
+        src: "{{ gpg_fixture_dir }}/private.fpr"
+      register: gpg_converge_private_fpr
+
+    - name: Read the staged private key
+      ansible.builtin.slurp:
+        src: "{{ gpg_fixture_dir }}/private.asc"
+      register: gpg_converge_private_key
+
+    - name: Read the staged public key fingerprint
+      ansible.builtin.slurp:
+        src: "{{ gpg_fixture_dir }}/public.fpr"
+      register: gpg_converge_public_fpr
+
+    - name: Read the staged public key
+      ansible.builtin.slurp:
+        src: "{{ gpg_fixture_dir }}/public.asc"
+      register: gpg_converge_public_key
+  roles:
+    - role: tborealis.roles.gpg

--- a/roles/gpg/molecule/default/molecule.yml
+++ b/roles/gpg/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/gpg/molecule/default/prepare.yml
+++ b/roles/gpg/molecule/default/prepare.yml
@@ -1,0 +1,138 @@
+---
+# The role imports existing key material for existing users, so create the
+# user and generate throwaway keys to feed it: one passphrase-protected
+# private key and one public key. Generation happens on the control node
+# (requires gpg there; the container image deliberately ships without GnuPG
+# because installing it is the role's job) and the armoured exports are
+# staged on the target for converge.yml and verify.yml to slurp.
+- name: Prepare
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Create the target user
+      ansible.builtin.user:
+        name: "{{ gpg_test_user }}"
+        shell: /bin/bash
+
+    - name: Create a scratch GNUPGHOME on the control node
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: .molecule-gpg
+      run_once: true
+      delegate_to: localhost
+      become: false
+      register: gpg_prepare_homedir
+
+    - name: Generate a throwaway private fixture key on the control node
+      ansible.builtin.command:
+        cmd: gpg --homedir {{ gpg_prepare_homedir.path }} --batch --pinentry-mode loopback --gen-key
+        stdin: |
+          Key-Type: RSA
+          Key-Length: 3072
+          Subkey-Type: RSA
+          Subkey-Length: 3072
+          Name-Real: Molecule Test Private
+          Name-Email: {{ gpg_test_private_uid }}
+          Expire-Date: 0
+          Passphrase: {{ gpg_test_passphrase }}
+          %commit
+      run_once: true
+      delegate_to: localhost
+      become: false
+      changed_when: true
+
+    - name: Generate a throwaway public fixture key on the control node
+      ansible.builtin.command:
+        cmd: gpg --homedir {{ gpg_prepare_homedir.path }} --batch --pinentry-mode loopback --gen-key
+        stdin: |
+          Key-Type: RSA
+          Key-Length: 3072
+          Subkey-Type: RSA
+          Subkey-Length: 3072
+          Name-Real: Molecule Test Public
+          Name-Email: {{ gpg_test_public_uid }}
+          Expire-Date: 0
+          %no-protection
+          %commit
+      run_once: true
+      delegate_to: localhost
+      become: false
+      changed_when: true
+
+    - name: Read the fixture key fingerprints
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail;
+          gpg --homedir {{ gpg_prepare_homedir.path }} --list-keys --with-colons {{ item }}
+          | awk -F: '$1 == "fpr" {print $10; exit}'
+        executable: /bin/bash
+      loop:
+        - "{{ gpg_test_private_uid }}"
+        - "{{ gpg_test_public_uid }}"
+      run_once: true
+      delegate_to: localhost
+      become: false
+      changed_when: false
+      register: gpg_prepare_fprs
+
+    - name: Export the armoured private fixture key
+      ansible.builtin.command: >-
+        gpg --homedir {{ gpg_prepare_homedir.path }} --batch --pinentry-mode loopback
+        --passphrase {{ gpg_test_passphrase }} --armor
+        --export-secret-keys {{ gpg_prepare_fprs.results[0].stdout }}
+      run_once: true
+      delegate_to: localhost
+      become: false
+      changed_when: false
+      register: gpg_prepare_private_key
+
+    - name: Export the armoured public fixture key
+      ansible.builtin.command: >-
+        gpg --homedir {{ gpg_prepare_homedir.path }} --armor
+        --export {{ gpg_prepare_fprs.results[1].stdout }}
+      run_once: true
+      delegate_to: localhost
+      become: false
+      changed_when: false
+      register: gpg_prepare_public_key
+
+    - name: Stop the scratch gpg-agent on the control node
+      ansible.builtin.command: gpgconf --homedir {{ gpg_prepare_homedir.path }} --kill gpg-agent
+      run_once: true
+      delegate_to: localhost
+      become: false
+      changed_when: true
+      failed_when: false
+
+    - name: Remove the scratch GNUPGHOME
+      ansible.builtin.file:
+        path: "{{ gpg_prepare_homedir.path }}"
+        state: absent
+      run_once: true
+      delegate_to: localhost
+      become: false
+
+    - name: Create the fixture directory on the target
+      ansible.builtin.file:
+        path: "{{ gpg_fixture_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Stage the fixture material on the target
+      ansible.builtin.copy:
+        content: "{{ item.content }}"
+        dest: "{{ gpg_fixture_dir }}/{{ item.dest }}"
+        mode: "0644"
+      loop:
+        - dest: private.fpr
+          content: "{{ gpg_prepare_fprs.results[0].stdout }}"
+        - dest: private.asc
+          content: "{{ gpg_prepare_private_key.stdout }}"
+        - dest: public.fpr
+          content: "{{ gpg_prepare_fprs.results[1].stdout }}"
+        - dest: public.asc
+          content: "{{ gpg_prepare_public_key.stdout }}"
+      loop_control:
+        label: "{{ item.dest }}"

--- a/roles/gpg/molecule/default/vars.yml
+++ b/roles/gpg/molecule/default/vars.yml
@@ -1,0 +1,9 @@
+---
+# Shared by prepare.yml, converge.yml and verify.yml. The key material
+# itself is generated fresh by prepare.yml (throwaway keys, obviously
+# synthetic UIDs) and staged on the target under gpg_fixture_dir.
+gpg_test_user: molecule
+gpg_test_passphrase: molecule-Fixture-Passphrase1
+gpg_test_private_uid: molecule-test-private@example.invalid
+gpg_test_public_uid: molecule-test-public@example.invalid
+gpg_fixture_dir: /opt/molecule-gpg-fixtures

--- a/roles/gpg/molecule/default/verify.yml
+++ b/roles/gpg/molecule/default/verify.yml
@@ -1,0 +1,94 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Read the staged private key fingerprint
+      ansible.builtin.slurp:
+        src: "{{ gpg_fixture_dir }}/private.fpr"
+      register: gpg_verify_private_fpr_file
+
+    - name: Read the staged public key fingerprint
+      ansible.builtin.slurp:
+        src: "{{ gpg_fixture_dir }}/public.fpr"
+      register: gpg_verify_public_fpr_file
+
+    - name: Set fingerprint facts
+      ansible.builtin.set_fact:
+        gpg_verify_private_fpr: "{{ gpg_verify_private_fpr_file.content | b64decode | trim }}"
+        gpg_verify_public_fpr: "{{ gpg_verify_public_fpr_file.content | b64decode | trim }}"
+
+    - name: Stat the GPG home directory
+      ansible.builtin.stat:
+        path: /home/{{ gpg_test_user }}/.gnupg
+      register: gpg_verify_home
+
+    - name: Assert the GPG home is private to the user
+      ansible.builtin.assert:
+        that:
+          - gpg_verify_home.stat.isdir
+          - gpg_verify_home.stat.pw_name == gpg_test_user
+          - gpg_verify_home.stat.mode == '0700'
+
+    - name: Stat the temporary private key file the role imports from
+      ansible.builtin.stat:
+        path: /home/{{ gpg_test_user }}/.gnupg/{{ gpg_verify_private_fpr }}
+      register: gpg_verify_leftover
+      failed_when: gpg_verify_leftover.stat.exists
+
+    - name: List the imported secret key as the target user
+      ansible.builtin.command: gpg2 --list-secret-keys {{ gpg_verify_private_fpr }}
+      become_user: "{{ gpg_test_user }}"
+      become: true
+      register: gpg_verify_secret
+      changed_when: false
+
+    - name: Assert the private fixture key was imported
+      ansible.builtin.assert:
+        that:
+          - gpg_test_private_uid in gpg_verify_secret.stdout
+
+    - name: List the imported public key as the target user
+      ansible.builtin.command: gpg2 --list-keys {{ gpg_verify_public_fpr }}
+      become_user: "{{ gpg_test_user }}"
+      become: true
+      register: gpg_verify_public
+      changed_when: false
+
+    - name: Assert the public fixture key was imported
+      ansible.builtin.assert:
+        that:
+          - gpg_test_public_uid in gpg_verify_public.stdout
+
+    - name: Export owner trust as the target user
+      ansible.builtin.command: gpg2 --export-ownertrust
+      become_user: "{{ gpg_test_user }}"
+      become: true
+      register: gpg_verify_ownertrust
+      changed_when: false
+
+    - name: Assert the public fixture key is ultimately trusted
+      ansible.builtin.assert:
+        that:
+          - gpg_verify_public_fpr ~ ':6:' in gpg_verify_ownertrust.stdout
+
+    - name: Sign and verify a message with the imported private key
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail;
+          echo molecule
+          | gpg2 --batch --pinentry-mode loopback --passphrase {{ gpg_test_passphrase }}
+          --local-user {{ gpg_verify_private_fpr }} --clearsign
+          | gpg2 --verify
+        executable: /bin/bash
+      become_user: "{{ gpg_test_user }}"
+      become: true
+      register: gpg_verify_roundtrip
+      changed_when: false
+
+    - name: Assert the signature verified
+      ansible.builtin.assert:
+        that:
+          - "'Good signature' in gpg_verify_roundtrip.stderr"

--- a/roles/node/molecule/default/converge.yml
+++ b/roles/node/molecule/default/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    # Matches the version the apt_keys manifest pins for live key verification.
+    node_version: 22
+  roles:
+    - role: tborealis.roles.node

--- a/roles/node/molecule/default/molecule.yml
+++ b/roles/node/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/node/molecule/default/verify.yml
+++ b/roles/node/molecule/default/verify.yml
@@ -1,0 +1,45 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+    - name: Print the Node version
+      ansible.builtin.command: node --eval 'console.log(process.version)'
+      register: node_verify_version
+      changed_when: false
+
+    - name: Assert Node 22 is installed
+      ansible.builtin.assert:
+        that:
+          - node_verify_version.stdout.startswith('v22.')
+
+    - name: Run npm # noqa: command-instead-of-module (functional check that the binary works)
+      ansible.builtin.command: npm --version
+      register: node_verify_npm
+      changed_when: false
+
+    - name: Assert npm reports a version string
+      ansible.builtin.assert:
+        that:
+          - "node_verify_npm.stdout is match('^[0-9]+\\.[0-9]+\\.[0-9]+$')"
+
+    - name: Check the nodejs package origin
+      ansible.builtin.command: apt-cache policy nodejs
+      register: node_verify_policy
+      changed_when: false
+
+    - name: Assert nodejs comes from NodeSource
+      ansible.builtin.assert:
+        that:
+          - "'deb.nodesource.com' in node_verify_policy.stdout"
+
+    - name: Read the NodeSource apt source
+      ansible.builtin.slurp:
+        src: /etc/apt/sources.list.d/nodesource.sources
+      register: node_verify_sources
+
+    - name: Assert the NodeSource repo targets Node 22 and the central keyring
+      ansible.builtin.assert:
+        that:
+          - "'https://deb.nodesource.com/node_22.x' in node_verify_sources.content | b64decode"
+          - "'Signed-By: /etc/apt/keyrings/nodesource.gpg' in node_verify_sources.content | b64decode"

--- a/roles/nvm/molecule/default/converge.yml
+++ b/roles/nvm/molecule/default/converge.yml
@@ -1,0 +1,15 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    nvm_config:
+      - user: "{{ nvm_molecule_user }}"
+        default_version: "{{ nvm_molecule_node_major }}"
+        versions:
+          - version: "{{ nvm_molecule_node_major }}"
+            global_packages: []
+  roles:
+    - role: tborealis.roles.nvm

--- a/roles/nvm/molecule/default/molecule.yml
+++ b/roles/nvm/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/nvm/molecule/default/prepare.yml
+++ b/roles/nvm/molecule/default/prepare.yml
@@ -1,0 +1,22 @@
+---
+# The role configures nvm for existing accounts and relies on become_user
+# switching to them, which needs acl for unprivileged users. On real hosts the
+# base role installs acl and other roles create the accounts; neither is part
+# of the nvm role's contract.
+- name: Prepare
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Install acl for unprivileged become
+      ansible.builtin.apt:
+        pkg: acl
+        state: present
+        update_cache: true
+
+    - name: Create test user
+      ansible.builtin.user:
+        name: "{{ nvm_molecule_user }}"
+        shell: /bin/bash
+        create_home: true

--- a/roles/nvm/molecule/default/vars.yml
+++ b/roles/nvm/molecule/default/vars.yml
@@ -1,0 +1,4 @@
+---
+# Shared by prepare.yml, converge.yml and verify.yml.
+nvm_molecule_user: molecule
+nvm_molecule_node_major: 22

--- a/roles/nvm/molecule/default/verify.yml
+++ b/roles/nvm/molecule/default/verify.yml
@@ -1,0 +1,38 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    # nvm appends its init lines to ~/.bashrc, which non-interactive shells
+    # return from early, so source nvm.sh explicitly instead of using bash -l.
+    - name: Check nvm version as the test user
+      become_user: "{{ nvm_molecule_user }}"
+      become: true
+      ansible.builtin.shell: . "$HOME/.nvm/nvm.sh" && nvm --version
+      args:
+        executable: /bin/bash
+      register: nvm_verify_version
+      changed_when: false
+
+    - name: Assert nvm reports a version string
+      ansible.builtin.assert:
+        that:
+          - "nvm_verify_version.stdout is match('^[0-9]+\\.[0-9]+\\.[0-9]+$')"
+
+    # Sourcing nvm.sh activates the default alias, so this checks both the
+    # installed version and the default set by converge.
+    - name: Check the default Node version as the test user
+      become_user: "{{ nvm_molecule_user }}"
+      become: true
+      ansible.builtin.shell: . "$HOME/.nvm/nvm.sh" && node --version
+      args:
+        executable: /bin/bash
+      register: nvm_verify_node_version
+      changed_when: false
+
+    - name: Assert the default Node major matches the converge config
+      ansible.builtin.assert:
+        that:
+          - nvm_verify_node_version.stdout.startswith('v' ~ nvm_molecule_node_major ~ '.')

--- a/roles/nvm/tasks/per_user.yml
+++ b/roles/nvm/tasks/per_user.yml
@@ -15,7 +15,7 @@
         set -o pipefail && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v{{ nvm_version }}/install.sh | bash
       args:
         executable: /bin/bash
-        creates: "{{ ansible_facts['env']['HOME'] }}/.nvm/nvm.sh"
+      changed_when: true
       when: nvm_installed_version.stdout != nvm_version
 
     - name: Per-version nvm config
@@ -24,6 +24,13 @@
       loop_control:
         loop_var: nvm_user_config_version
 
+    - name: Check default Node version alias
+      ansible.builtin.command: 'bash -ic "cat \"$NVM_DIR/alias/default\""'
+      register: nvm_default_alias
+      failed_when: false
+      changed_when: false
+
     - name: "Set default Node version to {{ nvm_user_config.default_version }}"
       ansible.builtin.command: 'bash -ic "nvm alias default {{ nvm_user_config.default_version }}"'
       changed_when: true
+      when: nvm_default_alias.stdout != nvm_user_config.default_version | string

--- a/roles/nvm/tasks/per_version.yml
+++ b/roles/nvm/tasks/per_version.yml
@@ -1,7 +1,8 @@
 ---
 - name: "Install Node version {{ nvm_user_config_version.version }}"
   ansible.builtin.command: 'bash -ic "nvm install {{ nvm_user_config_version.version }}"'
-  changed_when: true
+  register: nvm_install_result
+  changed_when: "'is already installed' not in nvm_install_result.stderr"
   when: nvm_user_config_version.version != 'system'
 
 - name: "Enable package managers for Node version {{ nvm_user_config_version.version }}"

--- a/roles/stripe_cli/molecule/default/converge.yml
+++ b/roles/stripe_cli/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  roles:
+    - role: tborealis.roles.stripe_cli

--- a/roles/stripe_cli/molecule/default/molecule.yml
+++ b/roles/stripe_cli/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/stripe_cli/molecule/default/vars.yml
+++ b/roles/stripe_cli/molecule/default/vars.yml
@@ -1,0 +1,4 @@
+---
+# The role has no default for stripe_cli_version (it is required) and pins
+# the exact release it installs, so any published version stays valid here.
+stripe_cli_version: 1.43.8

--- a/roles/stripe_cli/molecule/default/verify.yml
+++ b/roles/stripe_cli/molecule/default/verify.yml
@@ -1,0 +1,25 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Check the stripe version
+      ansible.builtin.command: stripe --version
+      register: stripe_cli_verify_version
+      changed_when: false
+
+    - name: Assert the pinned stripe version is installed
+      ansible.builtin.assert:
+        that:
+          - stripe_cli_verify_version.stdout is search('stripe version ' ~ stripe_cli_version)
+
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+
+    - name: Assert the deb is registered with dpkg at the pinned version
+      ansible.builtin.assert:
+        that:
+          - "'stripe' in ansible_facts.packages"
+          - ansible_facts.packages['stripe'][0].version == stripe_cli_version | string

--- a/roles/stripe_cli/tasks/main.yml
+++ b/roles/stripe_cli/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check existing stripe version
-  ansible.builtin.command: /usr/local/bin/stripe --version
+  ansible.builtin.command: /usr/bin/stripe --version
   changed_when: false
   failed_when: stripe_cli_version_result.rc not in [0, 2]
   register: stripe_cli_version_result

--- a/roles/yarn/molecule/default/converge.yml
+++ b/roles/yarn/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: tborealis.roles.yarn

--- a/roles/yarn/molecule/default/molecule.yml
+++ b/roles/yarn/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/yarn/molecule/default/verify.yml
+++ b/roles/yarn/molecule/default/verify.yml
@@ -1,0 +1,27 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+    # yarn is a Node script, so this also proves the deb's nodejs dependency
+    # was satisfied.
+    - name: Run yarn # noqa: command-instead-of-module (functional check that the binary works)
+      ansible.builtin.command: yarn --version
+      register: yarn_verify_version
+      changed_when: false
+
+    - name: Assert yarn reports a version string
+      ansible.builtin.assert:
+        that:
+          - "yarn_verify_version.stdout is match('^[0-9]+\\.[0-9]+\\.[0-9]+$')"
+
+    - name: Read the Yarn apt source
+      ansible.builtin.slurp:
+        src: /etc/apt/sources.list.d/yarn.sources
+      register: yarn_verify_sources
+
+    - name: Assert the Yarn repo is configured with the central keyring
+      ansible.builtin.assert:
+        that:
+          - "'https://dl.yarnpkg.com/debian/' in yarn_verify_sources.content | b64decode"
+          - "'Signed-By: /etc/apt/keyrings/yarn-repo.gpg' in yarn_verify_sources.content | b64decode"


### PR DESCRIPTION
## Summary

Batch 5 of the testing rollout: Molecule scenarios for **node**, **nvm**, **yarn**, **chrome**, **stripe_cli**, and **gpg**. All pass converge → idempotence → verify on bookworm and trixie locally.

### Bugs found and fixed

- **nvm was non-idempotent**: `nvm install` and `nvm alias default` ran with unconditional `changed_when: true` every converge; the installer's `creates:` guard also checked the *connection* user's HOME (never matching) and would have blocked nvm upgrades had it worked. Installs now detect "is already installed", the alias is compared to the stored default, and the broken guard is gone.
- **stripe_cli re-downloaded its deb every run**: the version check probed `/usr/local/bin/stripe` but the package installs `/usr/bin/stripe`.
- **chrome could not converge on a minimal host**: `@puppeteer/browsers` needs `unzip` to extract the archive; it's now in `chrome_system_dependencies`.

### Scenario highlights

- nvm: per-user install verified through a login shell as that user (default alias activates Node 22)
- gpg: throwaway keypairs generated on the control node at prepare time; verifies import, ownertrust, and a clearsign→verify round-trip as the target user
- chrome: `--version` plus a real headless `--dump-dom` render
- node/yarn: version + origin assertions against NodeSource/Yarn repos

### Also

- `.claude/` (agent worktrees) excluded from ansible-lint.

### Noticed but not fixed (tracked for the end-of-rollout report)

- nvm/node corepack tasks remain latently non-idempotent when enabled; nvm global-package installs likewise
- nvm pins an old installer version (0.39.7) and its README references a checksum that no longer exists
- chrome's dependency list uses pre-t64 package names (works via virtual packages on trixie)