### PR TITLE
Add molecule scenarios for the cloud and heavy roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,22 @@ flagged with **BREAKING** and require a MAJOR version bump.
   `stripe_cli`, and `gpg`.
 - **meta:** Molecule scenarios for the system config roles: `cron`, `sudo`, `dotenv`,
   `environment`, `apt_keys`, `rrsync`, and `exim4`.
+- **meta:** Molecule scenarios for the cloud and heavy roles: `base`, `aws_cli`,
+  `aws_config`, `do_agent`, and `dbcd` — every role in the collection now has one.
+- **base:** `base_hosts_unsafe_writes` (default `false`) writes `/etc/hosts` in place
+  for containers, where the bind mount breaks the default atomic rename.
 
 ### Fixed
+
+- **do_agent:** refresh the apt cache after adding the repository; the install task's
+  `cache_valid_time` treated the pre-repo cache as fresh, so a first install failed
+  with `No package matching 'do-agent'`. Same fix the other repo roles received in
+  v4.0.2.
+- **base:** the default locale is written through the `/etc/default/locale` symlink
+  the locales package creates; without `follow` the template replaced the symlink on
+  the run after a fresh install, so the role was never idempotent on first provision.
+- **aws_cli:** the role now creates `/etc/bash_completion.d` instead of assuming
+  another package has installed it.
 
 - **nvm:** version installs and the default alias reported changed on every run; they
   now detect the existing state. The installer's `creates:` guard checked the wrong

--- a/roles/aws_cli/molecule/default/converge.yml
+++ b/roles/aws_cli/molecule/default/converge.yml
@@ -1,0 +1,17 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    # The container mounts /tmp as tmpfs, which docker mounts noexec; the
+    # external role's installer must run from its download dir.
+    awscli_download_path: /var/tmp
+    aws_cli_config:
+      - user: "{{ aws_cli_molecule_user }}"
+        default_region: "{{ aws_cli_molecule_region }}"
+        access_key_id: "{{ aws_cli_molecule_access_key_id }}"
+        secret_access_key: "{{ aws_cli_molecule_secret_access_key }}"
+  roles:
+    - role: tborealis.roles.aws_cli

--- a/roles/aws_cli/molecule/default/molecule.yml
+++ b/roles/aws_cli/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/aws_cli/molecule/default/prepare.yml
+++ b/roles/aws_cli/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+# The wrapped ecgalaxy.aws_cli role unarchives the AWS CLI zip and verifies
+# its signature with gpg, but assumes unzip and gnupg are already installed
+# (its own CI prepares them via ecgalaxy.common_packages). The per-user config
+# tasks rely on become_user switching to an unprivileged account, which needs
+# acl, and on the account existing; on real hosts the base role installs acl
+# and other roles create the accounts. None of this is part of the role's
+# contract.
+- name: Prepare
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Install prerequisites of the wrapped role and unprivileged become
+      ansible.builtin.apt:
+        pkg:
+          - unzip
+          - gnupg
+          - acl
+        state: present
+        update_cache: true
+
+    - name: Create test user
+      ansible.builtin.user:
+        name: "{{ aws_cli_molecule_user }}"
+        shell: /bin/bash
+        create_home: true

--- a/roles/aws_cli/molecule/default/vars.yml
+++ b/roles/aws_cli/molecule/default/vars.yml
@@ -1,0 +1,10 @@
+---
+# Shared by prepare.yml, converge.yml and verify.yml.
+# The credentials are deliberately synthetic shapes: a real access key ID
+# matches AKIA[0-9A-Z]{16} and a real secret is 40 base64-ish characters,
+# both of which trip GitHub push protection and secret scanners. XKIA is not
+# a valid AWS prefix and the secret is a readable placeholder string.
+aws_cli_molecule_user: molecule
+aws_cli_molecule_region: eu-west-1
+aws_cli_molecule_access_key_id: XKIAMOLECULETEST0000
+aws_cli_molecule_secret_access_key: molecule-test-secret-access-key-not-real

--- a/roles/aws_cli/molecule/default/verify.yml
+++ b/roles/aws_cli/molecule/default/verify.yml
@@ -1,0 +1,89 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Check the AWS CLI version
+      ansible.builtin.command: aws --version
+      register: aws_cli_verify_version
+      changed_when: false
+
+    - name: Assert AWS CLI v2 is installed
+      ansible.builtin.assert:
+        that:
+          - aws_cli_verify_version.stdout.startswith('aws-cli/2.')
+
+    - name: Check the Session Manager plugin version
+      ansible.builtin.command: session-manager-plugin --version
+      register: aws_cli_verify_ssm_version
+      changed_when: false
+
+    - name: Assert the Session Manager plugin is installed
+      ansible.builtin.assert:
+        that:
+          - aws_cli_verify_ssm_version.stdout is match('^[0-9]+(\.[0-9]+)+$')
+
+    - name: Read the bash completion file
+      ansible.builtin.slurp:
+        src: /etc/bash_completion.d/aws-cli
+      register: aws_cli_verify_completion
+
+    - name: Assert completion hooks aws_completer
+      ansible.builtin.assert:
+        that:
+          - "\"complete -C '/usr/local/bin/aws_completer' aws\" in aws_cli_verify_completion.content | b64decode"
+
+    - name: Stat the per-user .aws directory
+      ansible.builtin.stat:
+        path: "/home/{{ aws_cli_molecule_user }}/.aws"
+      register: aws_cli_verify_dir
+
+    - name: Assert the .aws directory is private to the user
+      ansible.builtin.assert:
+        that:
+          - aws_cli_verify_dir.stat.isdir
+          - aws_cli_verify_dir.stat.pw_name == aws_cli_molecule_user
+          - aws_cli_verify_dir.stat.mode == '0700'
+
+    - name: Stat the per-user config files
+      ansible.builtin.stat:
+        path: "/home/{{ aws_cli_molecule_user }}/.aws/{{ item }}"
+      loop:
+        - config
+        - credentials
+      register: aws_cli_verify_files
+
+    - name: Assert the config files are private to the user
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+          - item.stat.pw_name == aws_cli_molecule_user
+          - item.stat.mode == '0600'
+      loop: "{{ aws_cli_verify_files.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Read the per-user credentials file
+      ansible.builtin.slurp:
+        src: "/home/{{ aws_cli_molecule_user }}/.aws/credentials"
+      register: aws_cli_verify_credentials
+
+    - name: Assert the credentials hold the converge keys
+      ansible.builtin.assert:
+        that:
+          - "'aws_access_key_id = ' ~ aws_cli_molecule_access_key_id in aws_cli_verify_credentials.content | b64decode"
+          - "'aws_secret_access_key = ' ~ aws_cli_molecule_secret_access_key in aws_cli_verify_credentials.content | b64decode"
+
+    - name: Read the configured region back through the CLI as the test user
+      become_user: "{{ aws_cli_molecule_user }}"
+      become: true
+      ansible.builtin.command: aws configure get region
+      register: aws_cli_verify_region
+      changed_when: false
+
+    - name: Assert the CLI resolves the region set by converge
+      ansible.builtin.assert:
+        that:
+          - aws_cli_verify_region.stdout == aws_cli_molecule_region

--- a/roles/aws_cli/tasks/main.yml
+++ b/roles/aws_cli/tasks/main.yml
@@ -4,6 +4,14 @@
     name: ecgalaxy.aws_cli
     allow_duplicates: false
 
+- name: Create bash completion directory
+  ansible.builtin.file:
+    path: /etc/bash_completion.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
 - name: Configure bash completion
   ansible.builtin.template:
     src: bash_completion.j2

--- a/roles/aws_config/molecule/default/converge.yml
+++ b/roles/aws_config/molecule/default/converge.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    aws_config:
+      - user: "{{ aws_config_molecule_user }}"
+        profiles:
+          - name: default
+            region: "{{ aws_config_molecule_default_region }}"
+            access_key_id: "{{ aws_config_molecule_default_access_key_id }}"
+            secret_access_key: "{{ aws_config_molecule_default_secret_access_key }}"
+          - name: backup
+            region: "{{ aws_config_molecule_backup_region }}"
+            access_key_id: "{{ aws_config_molecule_backup_access_key_id }}"
+            secret_access_key: "{{ aws_config_molecule_backup_secret_access_key }}"
+  roles:
+    - role: tborealis.roles.aws_config

--- a/roles/aws_config/molecule/default/molecule.yml
+++ b/roles/aws_config/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/aws_config/molecule/default/prepare.yml
+++ b/roles/aws_config/molecule/default/prepare.yml
@@ -1,0 +1,22 @@
+---
+# The role configures existing accounts and relies on become_user switching
+# to them, which needs acl for unprivileged users. On real hosts the base
+# role installs acl and other roles create the accounts; neither is part of
+# the aws_config role's contract.
+- name: Prepare
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Install acl for unprivileged become
+      ansible.builtin.apt:
+        pkg: acl
+        state: present
+        update_cache: true
+
+    - name: Create test user
+      ansible.builtin.user:
+        name: "{{ aws_config_molecule_user }}"
+        shell: /bin/bash
+        create_home: true

--- a/roles/aws_config/molecule/default/vars.yml
+++ b/roles/aws_config/molecule/default/vars.yml
@@ -1,0 +1,13 @@
+---
+# Shared by prepare.yml, converge.yml and verify.yml.
+# The credentials are deliberately synthetic shapes: a real access key ID
+# matches AKIA[0-9A-Z]{16} and a real secret is 40 base64-ish characters,
+# both of which trip GitHub push protection and secret scanners. XKIA is not
+# a valid AWS prefix and the secrets are readable placeholder strings.
+aws_config_molecule_user: molecule
+aws_config_molecule_default_region: eu-west-1
+aws_config_molecule_default_access_key_id: XKIAMOLECULETEST0001
+aws_config_molecule_default_secret_access_key: molecule-default-secret-key-not-real
+aws_config_molecule_backup_region: eu-west-2
+aws_config_molecule_backup_access_key_id: XKIAMOLECULETEST0002
+aws_config_molecule_backup_secret_access_key: molecule-backup-secret-key-not-real

--- a/roles/aws_config/molecule/default/verify.yml
+++ b/roles/aws_config/molecule/default/verify.yml
@@ -1,0 +1,64 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Stat the per-user .aws directory
+      ansible.builtin.stat:
+        path: "/home/{{ aws_config_molecule_user }}/.aws"
+      register: aws_config_verify_dir
+
+    - name: Assert the .aws directory is private to the user
+      ansible.builtin.assert:
+        that:
+          - aws_config_verify_dir.stat.isdir
+          - aws_config_verify_dir.stat.pw_name == aws_config_molecule_user
+          - aws_config_verify_dir.stat.mode == '0700'
+
+    - name: Stat the per-user config files
+      ansible.builtin.stat:
+        path: "/home/{{ aws_config_molecule_user }}/.aws/{{ item }}"
+      loop:
+        - config
+        - credentials
+      register: aws_config_verify_files
+
+    - name: Assert the config files are private to the user
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+          - item.stat.pw_name == aws_config_molecule_user
+          - item.stat.mode == '0600'
+      loop: "{{ aws_config_verify_files.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Read the per-user config file
+      ansible.builtin.slurp:
+        src: "/home/{{ aws_config_molecule_user }}/.aws/config"
+      register: aws_config_verify_config
+
+    - name: Assert both profiles and their regions are configured
+      ansible.builtin.assert:
+        that:
+          - "'[default]' in aws_config_verify_config.content | b64decode"
+          - "'region = ' ~ aws_config_molecule_default_region in aws_config_verify_config.content | b64decode"
+          - "'[profile backup]' in aws_config_verify_config.content | b64decode"
+          - "'region = ' ~ aws_config_molecule_backup_region in aws_config_verify_config.content | b64decode"
+
+    - name: Read the per-user credentials file
+      ansible.builtin.slurp:
+        src: "/home/{{ aws_config_molecule_user }}/.aws/credentials"
+      register: aws_config_verify_credentials
+
+    - name: Assert both profiles hold the converge keys
+      ansible.builtin.assert:
+        that:
+          - "'[default]' in aws_config_verify_credentials.content | b64decode"
+          - "'aws_access_key_id = ' ~ aws_config_molecule_default_access_key_id in aws_config_verify_credentials.content | b64decode"
+          - "'aws_secret_access_key = ' ~ aws_config_molecule_default_secret_access_key in aws_config_verify_credentials.content | b64decode"
+          - "'[backup]' in aws_config_verify_credentials.content | b64decode"
+          - "'aws_access_key_id = ' ~ aws_config_molecule_backup_access_key_id in aws_config_verify_credentials.content | b64decode"
+          - "'aws_secret_access_key = ' ~ aws_config_molecule_backup_secret_access_key in aws_config_verify_credentials.content | b64decode"

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -21,3 +21,4 @@ Base system configuration including locales, timezone, users, DNS, and essential
 | `ssh_allow_tcp_forwarding` | `false` | Allow SSH TCP forwarding |
 | `base_default_system_packages` | See defaults | Essential system packages |
 | `base_profile_config` | `[]` | Profile configuration entries |
+| `base_hosts_unsafe_writes` | `false` | Write /etc/hosts in place (for containers, where the bind mount breaks atomic renames) |

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -33,3 +33,6 @@ base_default_system_packages:
 base_use_backports: "{{ ansible_facts['distribution_release'] == 'bookworm' }}"
 base_profile_config: []
 base_config_dhclient: "{{ ansible_facts['distribution_release'] == 'bookworm' }}"
+# In-place /etc/hosts writes for containers, where the bind mount breaks the
+# default atomic rename.
+base_hosts_unsafe_writes: false

--- a/roles/base/molecule/default/converge.yml
+++ b/roles/base/molecule/default/converge.yml
@@ -1,0 +1,49 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    # Docker bind-mounts /etc/hosts, so the atomic rename in "Clean /etc/hosts"
+    # fails with EBUSY; the role falls back to an in-place write.
+    base_hosts_unsafe_writes: true
+    system_locales:
+      - en_GB.UTF-8
+    system_default_locale: en_GB.UTF-8
+    system_timezone: Europe/London
+    # cron also satisfies the role's "Restart cron" handler: the test image
+    # ships without cron, and the packages task runs before the handler fires.
+    system_packages:
+      - cron
+    dns_primary_nameserver: 9.9.9.9
+    dns_secondary_nameserver: 149.112.112.112
+    local_hostnames:
+      - molecule-base.example.invalid
+    known_hosts:
+      - "{{ base_molecule_known_host_entry }}"
+    ssh_extra_user_groups:
+      - sftp-users
+    ssh_allow_tcp_forwarding: true
+    base_profile_config:
+      - src: molecule-profile.sh.j2
+        dest: molecule-profile.sh
+    default_users:
+      - name: molecule-admin
+        password: "{{ base_molecule_admin_password_hash }}"
+        groups:
+          - ssh-users
+          - sudo
+        authorized_keys:
+          - "{{ base_molecule_admin_key_file }}"
+    users:
+      - name: molecule-deploy
+        password: "{{ base_molecule_deploy_password_hash }}"
+        groups:
+          - ssh-users
+          - sftp-users
+        shell: /bin/bash
+        authorized_keys:
+          - "{{ base_molecule_deploy_key_file }}"
+  roles:
+    - role: tborealis.roles.base

--- a/roles/base/molecule/default/files/molecule_admin_ed25519.pub
+++ b/roles/base/molecule/default/files/molecule_admin_ed25519.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN36e+3E9pYQ32bJkwyw6b+VjW5424kI4zJOa3dzQ5TC molecule-admin@example.invalid

--- a/roles/base/molecule/default/files/molecule_deploy_ed25519.pub
+++ b/roles/base/molecule/default/files/molecule_deploy_ed25519.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICbzPZJR4Qd3j8m6atlA5L7aW4ffJFIZSyOS5hB1lKeW molecule-deploy@example.invalid

--- a/roles/base/molecule/default/molecule.yml
+++ b/roles/base/molecule/default/molecule.yml
@@ -1,0 +1,32 @@
+---
+# Overrides the base platforms (lists replace): the role drives
+# systemd-hostnamed and systemd-timedated over D-Bus (hostname and timezone
+# management), and those sandboxed units cannot set up their mount
+# namespacing in unprivileged containers, so these containers run
+# privileged. Both releases still run, so no .config/molecule/platforms.yml
+# entry is needed.
+platforms:
+  - name: bookworm
+    image: ${MOLECULE_IMAGE_REPO:-ghcr.io/tborealis/ansible-roles}/molecule-debian:bookworm
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    cgroupns_mode: host
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+  - name: trixie
+    image: ${MOLECULE_IMAGE_REPO:-ghcr.io/tborealis/ansible-roles}/molecule-debian:trixie
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    cgroupns_mode: host
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp

--- a/roles/base/molecule/default/prepare.yml
+++ b/roles/base/molecule/default/prepare.yml
@@ -1,0 +1,30 @@
+---
+# Prerequisites outside the role's contract:
+# - bookworm images ship without a DHCP client, but the role templates
+#   /etc/dhcp/dhclient.conf assuming a standard DHCP-managed Debian server.
+# - a pre-existing user with a stray authorized key simulates adopting an
+#   existing host, so verify can prove the role's exclusive key handling
+#   removes keys it does not manage.
+- name: Prepare
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Install the DHCP client whose config the role manages
+      ansible.builtin.apt:
+        pkg: isc-dhcp-client
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_facts['distribution_release'] == 'bookworm'
+
+    - name: Create a pre-existing legacy user for the role to adopt
+      ansible.builtin.user:
+        name: molecule-deploy
+        shell: /bin/sh
+
+    - name: Plant a stray authorized key the role must remove
+      ansible.posix.authorized_key:
+        user: molecule-deploy
+        key: "{{ base_molecule_stray_public_key }}"

--- a/roles/base/molecule/default/templates/molecule-profile.sh.j2
+++ b/roles/base/molecule/default/templates/molecule-profile.sh.j2
@@ -1,0 +1,4 @@
+#
+# {{ ansible_managed }}
+#
+export MOLECULE_BASE_PROFILE="{{ base_molecule_profile_marker }}"

--- a/roles/base/molecule/default/vars.yml
+++ b/roles/base/molecule/default/vars.yml
@@ -1,0 +1,21 @@
+---
+# Throwaway fixtures shared by prepare.yml, converge.yml and verify.yml.
+# The hashes are `openssl passwd -6` of molecule-only passwords; the public
+# keys are synthetic ed25519 keys whose private halves were discarded.
+base_molecule_admin_password_hash: >-
+  $6$moleculeAdmin000$0uKXh68arnRtxE2MUi/50vogX1pSuM6sV1BYeWeht0Dl1X.GgNJY/MaQB6MmALdBy4WrvZRSC3Vp6/DJMYgzP.
+base_molecule_deploy_password_hash: >-
+  $6$moleculeDeploy00$qb27YKPZks2EyONPoEtFR8/3bmRtIatVli0VFVPsZZnRaiHVncujkk/NBpL.UF6LjRZ8wN.QU6wSdh.TZV2BX/
+# Public keys the role must authorize (looked up from the controller by the
+# role's `lookup('file', ...)`).
+base_molecule_admin_key_file: "{{ playbook_dir }}/files/molecule_admin_ed25519.pub"
+base_molecule_deploy_key_file: "{{ playbook_dir }}/files/molecule_deploy_ed25519.pub"
+# Pre-seeded by prepare.yml; the role's exclusive authorized_keys handling
+# must remove it.
+base_molecule_stray_public_key: >-
+  ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOJ+QKrnxd+r/3XFDmz1SDzRLoxBDftQ7fk8ORY4Weld
+  molecule-stray@example.invalid
+base_molecule_known_host_entry: >-
+  git.example.invalid ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIP8QQcF+eRz4HQgPTdz/Zxjrlxm++Y4aLWF18nZinmf
+  molecule-knownhost@example.invalid
+base_molecule_profile_marker: molecule-base-profile-marker

--- a/roles/base/molecule/default/verify.yml
+++ b/roles/base/molecule/default/verify.yml
@@ -1,0 +1,244 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Check the runtime hostname # noqa: command-instead-of-module
+      ansible.builtin.command: hostname
+      register: base_verify_hostname
+      changed_when: false
+
+    - name: Assert the hostname matches the inventory name
+      ansible.builtin.assert:
+        that:
+          - base_verify_hostname.stdout == inventory_hostname
+
+    - name: Read /etc/hosts
+      ansible.builtin.slurp:
+        src: /etc/hosts
+      register: base_verify_hosts
+
+    - name: Assert /etc/hosts was templated with the local hostname aliases
+      ansible.builtin.assert:
+        that:
+          - >-
+            '127.0.1.1 ' ~ inventory_hostname_short ~ ' ' ~ inventory_hostname
+            in base_verify_hosts.content | b64decode
+          - "'molecule-base.example.invalid' in base_verify_hosts.content | b64decode"
+
+    - name: Query the system timezone
+      ansible.builtin.command: timedatectl show --property=Timezone --value
+      register: base_verify_timezone
+      changed_when: false
+
+    - name: Stat the localtime symlink
+      ansible.builtin.stat:
+        path: /etc/localtime
+      register: base_verify_localtime
+
+    - name: Assert the timezone is Europe/London
+      ansible.builtin.assert:
+        that:
+          - base_verify_timezone.stdout == 'Europe/London'
+          - base_verify_localtime.stat.lnk_source.endswith('/Europe/London')
+
+    - name: List generated locales
+      ansible.builtin.command: locale -a
+      register: base_verify_locales
+      changed_when: false
+
+    - name: Read the default locale file
+      ansible.builtin.slurp:
+        src: /etc/default/locale
+      register: base_verify_default_locale
+
+    - name: Assert the en_GB locale was generated and set as default
+      ansible.builtin.assert:
+        that:
+          - "'en_GB.utf8' in base_verify_locales.stdout_lines"
+          - >-
+            'LANG="en_GB.UTF-8"' in base_verify_default_locale.content | b64decode
+
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+
+    - name: Assert default and extra system packages are installed
+      ansible.builtin.assert:
+        that:
+          - "'htop' in ansible_facts.packages"
+          - "'zstd' in ansible_facts.packages"
+          - "'openssh-server' in ansible_facts.packages"
+          - "'cron' in ansible_facts.packages"
+
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert cron and sshd are running
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['cron.service'].state == 'running'
+          - ansible_facts.services['ssh.service'].state == 'running'
+
+    - name: Read the passwd database
+      ansible.builtin.getent:
+        database: passwd
+
+    - name: Read the group database
+      ansible.builtin.getent:
+        database: group
+
+    - name: Assert managed users exist with a bash shell and group memberships
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.getent_passwd['molecule-admin'][5] == '/bin/bash'
+          - ansible_facts.getent_passwd['molecule-deploy'][5] == '/bin/bash'
+          - "'molecule-admin' in ansible_facts.getent_group['ssh-users'][2].split(',')"
+          - "'molecule-deploy' in ansible_facts.getent_group['ssh-users'][2].split(',')"
+          - "'molecule-admin' in ansible_facts.getent_group['sudo'][2].split(',')"
+          - "'molecule-deploy' in ansible_facts.getent_group['sftp-users'][2].split(',')"
+
+    - name: Stat the admin authorized_keys file
+      ansible.builtin.stat:
+        path: /home/molecule-admin/.ssh/authorized_keys
+      register: base_verify_admin_keys_stat
+
+    - name: Read the admin authorized_keys file
+      ansible.builtin.slurp:
+        src: /home/molecule-admin/.ssh/authorized_keys
+      register: base_verify_admin_keys
+
+    - name: Assert the admin key is authorized with safe ownership and mode
+      ansible.builtin.assert:
+        that:
+          - >-
+            lookup('file', base_molecule_admin_key_file)
+            in base_verify_admin_keys.content | b64decode
+          - base_verify_admin_keys_stat.stat.pw_name == 'molecule-admin'
+          - base_verify_admin_keys_stat.stat.mode == '0600'
+
+    - name: Read the deploy authorized_keys file
+      ansible.builtin.slurp:
+        src: /home/molecule-deploy/.ssh/authorized_keys
+      register: base_verify_deploy_keys
+
+    - name: Assert the deploy key is authorized and the stray key was removed
+      ansible.builtin.assert:
+        that:
+          - >-
+            lookup('file', base_molecule_deploy_key_file)
+            in base_verify_deploy_keys.content | b64decode
+          - >-
+            base_molecule_stray_public_key
+            not in base_verify_deploy_keys.content | b64decode
+
+    - name: Validate the full sshd configuration
+      ansible.builtin.command: sshd -t
+      changed_when: false
+
+    - name: Dump the effective sshd configuration
+      ansible.builtin.command: sshd -T
+      register: base_verify_sshd_config
+      changed_when: false
+
+    - name: Assert converge values are live in the effective sshd config
+      ansible.builtin.assert:
+        that:
+          - "'allowtcpforwarding yes' in base_verify_sshd_config.stdout_lines"
+          - "'allowgroups ssh-users' in base_verify_sshd_config.stdout_lines"
+          - "'allowgroups sftp-users' in base_verify_sshd_config.stdout_lines"
+          - "'x11forwarding no' in base_verify_sshd_config.stdout_lines"
+
+    - name: Stat the sshd drop-in
+      ansible.builtin.stat:
+        path: /etc/ssh/sshd_config.d/99-custom.conf
+      register: base_verify_sshd_dropin
+
+    - name: Read the sshd drop-in
+      ansible.builtin.slurp:
+        src: /etc/ssh/sshd_config.d/99-custom.conf
+      register: base_verify_sshd_dropin_content
+
+    - name: Assert the sshd drop-in content, ownership and mode
+      ansible.builtin.assert:
+        that:
+          - base_verify_sshd_dropin.stat.pw_name == 'root'
+          - base_verify_sshd_dropin.stat.mode == '0644'
+          - "'DebianBanner no' in base_verify_sshd_dropin_content.content | b64decode"
+
+    - name: Read the system known hosts file
+      ansible.builtin.slurp:
+        src: /etc/ssh/ssh_known_hosts
+      register: base_verify_known_hosts
+
+    - name: Assert the known host entry is present
+      ansible.builtin.assert:
+        that:
+          - base_molecule_known_host_entry in base_verify_known_hosts.content | b64decode
+
+    - name: Read the profile.d drop-in
+      ansible.builtin.slurp:
+        src: /etc/profile.d/molecule-profile.sh
+      register: base_verify_profile
+
+    - name: Assert the profile drop-in was templated
+      ansible.builtin.assert:
+        that:
+          - "'export MOLECULE_BASE_PROFILE=' in base_verify_profile.content | b64decode"
+          - base_molecule_profile_marker in base_verify_profile.content | b64decode
+
+    - name: Check the skel prompt uses the full-hostname escape
+      ansible.builtin.command: grep -F -c '\u@\H' /etc/skel/.bashrc
+      register: base_verify_skel_prompt
+      changed_when: false
+
+    - name: Check the short-hostname escape is gone from the skel prompt
+      ansible.builtin.command: grep -F -c '\u@\h' /etc/skel/.bashrc
+      register: base_verify_skel_prompt_short
+      changed_when: false
+      failed_when: base_verify_skel_prompt_short.rc != 1
+
+    - name: Verify bookworm-only networking and backports configuration
+      when: ansible_facts['distribution_release'] == 'bookworm'
+      block:
+        - name: Read dhclient.conf
+          ansible.builtin.slurp:
+            src: /etc/dhcp/dhclient.conf
+          register: base_verify_dhclient
+
+        - name: Assert the DNS servers are prepended in dhclient.conf
+          ansible.builtin.assert:
+            that:
+              - >-
+                'prepend domain-name-servers 9.9.9.9 149.112.112.112;'
+                in base_verify_dhclient.content | b64decode
+
+        - name: Stat the backports repo definition
+          ansible.builtin.stat:
+            path: /etc/apt/sources.list.d/debian-backports.sources
+          register: base_verify_backports
+
+        - name: Assert the backports repo is configured
+          ansible.builtin.assert:
+            that:
+              - base_verify_backports.stat.exists
+
+    - name: Verify trixie skips dhclient and backports
+      when: ansible_facts['distribution_release'] == 'trixie'
+      block:
+        - name: Stat dhclient.conf
+          ansible.builtin.stat:
+            path: /etc/dhcp/dhclient.conf
+          register: base_verify_dhclient_absent
+
+        - name: Stat the backports repo definition
+          ansible.builtin.stat:
+            path: /etc/apt/sources.list.d/debian-backports.sources
+          register: base_verify_backports_absent
+
+        - name: Assert dhclient.conf and backports are absent
+          ansible.builtin.assert:
+            that:
+              - not base_verify_dhclient_absent.stat.exists
+              - not base_verify_backports_absent.stat.exists

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -8,6 +8,9 @@
     src: networking/hosts.j2
     dest: /etc/hosts
     mode: "0644"
+    # Containers bind-mount /etc/hosts, which breaks the default atomic
+    # rename; the fallback writes in place.
+    unsafe_writes: "{{ base_hosts_unsafe_writes }}"
 
 - name: Set DHCP config
   ansible.builtin.template:

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -84,6 +84,9 @@
     src: locale.j2
     dest: /etc/default/locale
     mode: "0644"
+    # The locales package makes this a symlink to /etc/locale.conf; write
+    # through it instead of replacing it on the second run.
+    follow: true
 
 - name: Set default timezone
   community.general.timezone:

--- a/roles/dbcd/molecule/default/converge.yml
+++ b/roles/dbcd/molecule/default/converge.yml
@@ -1,0 +1,22 @@
+---
+# Server and consumer modes run on different machines in production, but both
+# are self-contained config changes, so one container exercises both. Client
+# mode is not converged: it requires an SSH private key variable, and test
+# fixtures here are public keys only.
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    dbcd_modes:
+      - server
+      - consumer
+    dbcd_server_client_public_key: "{{ dbcd_molecule_client_public_key }}"
+    dbcd_server_consumer_public_keys: "{{ dbcd_molecule_consumer_public_keys }}"
+    dbcd_consumer_user: "{{ dbcd_molecule_consumer_user }}"
+    dbcd_server_host: "{{ dbcd_molecule_server_host }}"
+    dbcd_known_hosts:
+      - "{{ dbcd_molecule_known_host }}"
+  roles:
+    - role: tborealis.roles.dbcd

--- a/roles/dbcd/molecule/default/molecule.yml
+++ b/roles/dbcd/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/dbcd/molecule/default/prepare.yml
+++ b/roles/dbcd/molecule/default/prepare.yml
@@ -1,0 +1,30 @@
+---
+# Server mode adds the dbcd user to the ssh-users group, which the base role
+# creates on real hosts; consumer mode configures an existing user's SSH
+# client config. Both are outside this role's contract.
+- name: Prepare
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: Create ssh-users group
+      ansible.builtin.group:
+        name: ssh-users
+        system: true
+
+    - name: Create consumer user
+      ansible.builtin.user:
+        name: "{{ dbcd_molecule_consumer_user }}"
+        password: "*"
+        shell: /bin/bash
+
+    # On real hosts the base role's authorized_key task creates ~/.ssh;
+    # the role's blockinfile only creates the config file, not the directory.
+    - name: Create consumer .ssh directory
+      ansible.builtin.file:
+        path: "/home/{{ dbcd_molecule_consumer_user }}/.ssh"
+        state: directory
+        owner: "{{ dbcd_molecule_consumer_user }}"
+        group: "{{ dbcd_molecule_consumer_user }}"
+        mode: "0700"

--- a/roles/dbcd/molecule/default/vars.yml
+++ b/roles/dbcd/molecule/default/vars.yml
@@ -1,0 +1,18 @@
+---
+# Throwaway fixtures shared by converge.yml and verify.yml. The SSH keys are
+# freshly generated ed25519 PUBLIC keys whose private halves were discarded.
+dbcd_molecule_client_public_key: >-
+  ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGmhl5yymEsq/ETnS6NvXvrjIv8mtR71cBV5O8m/PhWB
+  molecule-client@example.invalid
+dbcd_molecule_consumer_public_keys:
+  - >-
+    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMcPYUsUPytrmdyqgCHoH4+CwuEWPCF8cJOq46TrpaEW
+    molecule-consumer1@example.invalid
+  - >-
+    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICXlDJC0QW1C40hYxxHUPavKblM8vNRaCaJGn0/6T8VW
+    molecule-consumer2@example.invalid
+dbcd_molecule_consumer_user: molecule-consumer
+dbcd_molecule_server_host: dbcd-server.example.invalid
+dbcd_molecule_known_host: >-
+  dbcd-server.example.invalid ssh-ed25519
+  AAAAC3NzaC1lZDI1NTE5AAAAIGmhl5yymEsq/ETnS6NvXvrjIv8mtR71cBV5O8m/PhWB

--- a/roles/dbcd/molecule/default/verify.yml
+++ b/roles/dbcd/molecule/default/verify.yml
@@ -1,0 +1,136 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    # Role defaults: dbcd_server_user=dbcd, dbcd_data_dir=/home/dbcd/data
+    dbcd_verify_server_user: dbcd
+    dbcd_verify_data_dir: /home/dbcd/data
+  tasks:
+    # --- server mode ---
+    - name: Look up dbcd user
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ dbcd_verify_server_user }}"
+
+    - name: Assert dbcd user has the restricted shell
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.getent_passwd[dbcd_verify_server_user][5] == '/bin/dash'
+
+    - name: List dbcd user groups
+      ansible.builtin.command: id -nG {{ dbcd_verify_server_user }}
+      register: dbcd_verify_groups
+      changed_when: false
+
+    - name: Assert dbcd user is in the ssh-users group
+      ansible.builtin.assert:
+        that:
+          - "'ssh-users' in dbcd_verify_groups.stdout.split()"
+
+    - name: Look up dbcd password hash
+      ansible.builtin.getent:
+        database: shadow
+        key: "{{ dbcd_verify_server_user }}"
+
+    - name: Assert dbcd user cannot log in with a password
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.getent_shadow[dbcd_verify_server_user][0] == '*'
+
+    - name: Stat data directory
+      ansible.builtin.stat:
+        path: "{{ dbcd_verify_data_dir }}"
+      register: dbcd_verify_data_dir_stat
+
+    - name: Assert data directory ownership and mode
+      ansible.builtin.assert:
+        that:
+          - dbcd_verify_data_dir_stat.stat.isdir
+          - dbcd_verify_data_dir_stat.stat.pw_name == dbcd_verify_server_user
+          - dbcd_verify_data_dir_stat.stat.gr_name == dbcd_verify_server_user
+          - dbcd_verify_data_dir_stat.stat.mode == '0750'
+
+    - name: Stat authorized_keys file
+      ansible.builtin.stat:
+        path: "/home/{{ dbcd_verify_server_user }}/.ssh/authorized_keys"
+      register: dbcd_verify_authorized_keys_stat
+
+    - name: Assert authorized_keys ownership and mode
+      ansible.builtin.assert:
+        that:
+          - dbcd_verify_authorized_keys_stat.stat.pw_name == dbcd_verify_server_user
+          - dbcd_verify_authorized_keys_stat.stat.mode == '0600'
+
+    - name: Read authorized_keys
+      ansible.builtin.slurp:
+        src: "/home/{{ dbcd_verify_server_user }}/.ssh/authorized_keys"
+      register: dbcd_verify_authorized_keys
+
+    # Since v5.0.0 the key list is exclusive: the converged keys must be
+    # exactly what is present, nothing else.
+    - name: Assert authorized_keys contains exactly the converged keys with rrsync restrictions
+      vars:
+        dbcd_verify_expected_keys: >-
+          {{ ['command="rrsync -wo ' ~ dbcd_verify_data_dir ~ '" '
+              ~ dbcd_molecule_client_public_key]
+             + (dbcd_molecule_consumer_public_keys
+                | map('ansible.builtin.regex_replace', '^',
+                      'command="rrsync -ro ' ~ dbcd_verify_data_dir ~ '" ')
+                | list) }}
+        dbcd_verify_actual_keys: >-
+          {{ (dbcd_verify_authorized_keys.content | b64decode).splitlines()
+             | map('trim') | select | list }}
+      ansible.builtin.assert:
+        that:
+          - dbcd_verify_actual_keys | sort == dbcd_verify_expected_keys | sort
+
+    # --- consumer mode ---
+    - name: Stat consumer SSH config
+      ansible.builtin.stat:
+        path: "/home/{{ dbcd_molecule_consumer_user }}/.ssh/config"
+      register: dbcd_verify_ssh_config_stat
+
+    - name: Assert consumer SSH config ownership and mode
+      ansible.builtin.assert:
+        that:
+          - dbcd_verify_ssh_config_stat.stat.pw_name == dbcd_molecule_consumer_user
+          - dbcd_verify_ssh_config_stat.stat.mode == '0600'
+
+    - name: Read consumer SSH config
+      ansible.builtin.slurp:
+        src: "/home/{{ dbcd_molecule_consumer_user }}/.ssh/config"
+      register: dbcd_verify_ssh_config
+
+    - name: Assert consumer SSH config defines the read host alias
+      vars:
+        dbcd_verify_ssh_config_content: "{{ dbcd_verify_ssh_config.content | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - "'Host dbcd-server-r' in dbcd_verify_ssh_config_content"
+          - "'HostName ' ~ dbcd_molecule_server_host in dbcd_verify_ssh_config_content"
+          - "'User ' ~ dbcd_verify_server_user in dbcd_verify_ssh_config_content"
+          - "'# BEGIN-DBCD-R ANSIBLE MANAGED BLOCK' in dbcd_verify_ssh_config_content"
+
+    - name: Stat global known hosts
+      ansible.builtin.stat:
+        path: /etc/ssh/ssh_known_hosts
+      register: dbcd_verify_known_hosts_stat
+
+    - name: Assert global known hosts ownership and mode
+      ansible.builtin.assert:
+        that:
+          - dbcd_verify_known_hosts_stat.stat.pw_name == 'root'
+          - dbcd_verify_known_hosts_stat.stat.mode == '0644'
+
+    - name: Read global known hosts
+      ansible.builtin.slurp:
+        src: /etc/ssh/ssh_known_hosts
+      register: dbcd_verify_known_hosts
+
+    - name: Assert the server host key is a known host
+      ansible.builtin.assert:
+        that:
+          - dbcd_molecule_known_host in dbcd_verify_known_hosts.content | b64decode

--- a/roles/do_agent/molecule/default/converge.yml
+++ b/roles/do_agent/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: tborealis.roles.do_agent

--- a/roles/do_agent/molecule/default/molecule.yml
+++ b/roles/do_agent/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/do_agent/molecule/default/verify.yml
+++ b/roles/do_agent/molecule/default/verify.yml
@@ -1,0 +1,74 @@
+---
+# The agent authenticates against the DigitalOcean droplet metadata service,
+# which does not exist in a Molecule container, so the process may exit or
+# crash-loop after start. Verification therefore checks installation, repo
+# configuration and unit enablement, but deliberately does not assert the
+# service is in the "running" state.
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+
+    - name: Assert do-agent package is installed
+      ansible.builtin.assert:
+        that:
+          - "'do-agent' in ansible_facts.packages"
+
+    - name: Read apt repository source
+      ansible.builtin.slurp:
+        src: /etc/apt/sources.list.d/digitalocean-agent.sources
+      register: do_agent_verify_source
+
+    - name: Assert repository points at DigitalOcean and is pinned to the managed keyring
+      vars:
+        do_agent_verify_source_content: "{{ do_agent_verify_source.content | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - "'URIs: https://repos.insights.digitalocean.com/apt/do-agent' in do_agent_verify_source_content"
+          - "'Signed-By: /etc/apt/keyrings/digitalocean-agent-keyring.gpg' in do_agent_verify_source_content"
+
+    - name: Check legacy repository list file
+      ansible.builtin.stat:
+        path: /etc/apt/sources.list.d/digitalocean-agent.list
+      register: do_agent_verify_legacy_list
+      failed_when: do_agent_verify_legacy_list.stat.exists
+
+    - name: Check the managed keyring is installed
+      ansible.builtin.stat:
+        path: /etc/apt/keyrings/digitalocean-agent-keyring.gpg
+      register: do_agent_verify_keyring
+      failed_when: not do_agent_verify_keyring.stat.exists
+
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert do-agent unit exists and is enabled
+      ansible.builtin.assert:
+        that:
+          - "'do-agent.service' in ansible_facts.services"
+          - ansible_facts.services['do-agent.service'].status == 'enabled'
+
+    - name: Read do-agent unit file # noqa: command-instead-of-module (querying the unit file, no module equivalent)
+      ansible.builtin.command: systemctl cat do-agent.service
+      register: do_agent_verify_unit
+      changed_when: false
+
+    - name: Assert unit file starts the agent binary
+      ansible.builtin.assert:
+        that:
+          - "'do-agent' in do_agent_verify_unit.stdout"
+
+    - name: Check the agent binary referenced by ExecStart
+      vars:
+        do_agent_verify_binary: >-
+          {{ do_agent_verify_unit.stdout
+             | regex_search('ExecStart=(\S+)', '\1')
+             | first }}
+      ansible.builtin.stat:
+        path: "{{ do_agent_verify_binary }}"
+      register: do_agent_verify_binary_stat
+      failed_when: >-
+        not do_agent_verify_binary_stat.stat.exists
+        or not do_agent_verify_binary_stat.stat.executable

--- a/roles/do_agent/tasks/main.yaml
+++ b/roles/do_agent/tasks/main.yaml
@@ -14,11 +14,17 @@
     suites: main
     components: main
     signed_by: /etc/apt/keyrings/digitalocean-agent-keyring.gpg
+  register: do_agent_repo
 
 - name: Remove legacy repository list file
   ansible.builtin.file:
     path: /etc/apt/sources.list.d/digitalocean-agent.list
     state: absent
+
+- name: Update apt cache after adding repository # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: do_agent_repo is changed
 
 - name: Install agent
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary

Final batch of the testing rollout: Molecule scenarios for **base**, **aws_cli**, **aws_config**, **do_agent**, and **dbcd**. All pass converge → idempotence → verify on bookworm and trixie locally. **Every role in the collection now has functional test coverage.**

### Bugs found and fixed

- **do_agent could not install on a fresh host**: the install task's `cache_valid_time` treated the pre-repo cache as fresh, so `do-agent` was invisible after the repo was added. Same fix the other repo roles received in v4.0.2 — this role was missed.
- **base was never idempotent on a first provision**: the locales package makes `/etc/default/locale` a symlink to `/etc/locale.conf`; without `follow: true` the template replaced the symlink on the second run.
- **aws_cli assumed `/etc/bash_completion.d` exists**: the role now creates it (matching composer).
- **base** gains `base_hosts_unsafe_writes` (default false, no behaviour change): scoped in-place writes for bind-mounted `/etc/hosts` in containers. A play-wide `ANSIBLE_UNSAFE_WRITES` workaround left newly created files mode 777 for one run.

### Scenario highlights

- base runs privileged (hostname/timezone/locale need it); verifies live locale/timezone, **exclusive authorized keys** (a stray key planted in prepare must be removed — the v5.0.0 breaking behaviour), `sshd -T` effective config, and per-release backports/dhclient branches
- dbcd converges server + consumer modes and asserts the exclusive rrsync-restricted key set exactly
- aws_cli verifies the CLI/SSM binaries and a functional `aws configure get` as the target user; aws_config asserts multi-profile rendering (credentials deliberately not AWS-shaped for push protection)
- do_agent asserts package/repo/unit-enablement; running state can't be asserted off-droplet

An end-of-rollout report of findings noticed but deliberately not fixed follows separately.