### PR TITLE
Release v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [5.1.0] - 2026-07-14
+
 ### Added
 
 - **meta:** Molecule test infrastructure (systemd-enabled bookworm/trixie test images

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 5.0.0
+version: 5.1.0
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
Promotes `[Unreleased]` to **5.1.0** and bumps `galaxy.yml`.

MINOR bump: molecule test coverage for all 37 roles (new tooling, no role behaviour removed), one new variable (`base_hosts_unsafe_writes`, default off), and 11 backwards-compatible bug fixes found by the new tests. No breaking changes.

After merge: `git tag v5.1.0 && git push origin v5.1.0` — CI verifies the tag against galaxy.yml/CHANGELOG.md and publishes the GitHub Release.