### PR TITLE
certbot: make apache mode work standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+### Fixed
+
+- **certbot:** apache mode now works standalone: the role ships the `Restart apache2`
+  handler it notifies, defaults `apache2_ssl_vhosts` to `[]`, and documents the
+  variable and its playbook-relative `templates/apache2/vhosts/` contract. (#124)
+
 ## [5.1.0] - 2026-07-14
 
 ### Added

--- a/roles/certbot/README.md
+++ b/roles/certbot/README.md
@@ -19,6 +19,9 @@ certbot_certs: # array of certificates to request
   - test.example.com
   deploy_hook: /path/to/deploy.sh # optional script to run after certificate renewal
 certbot_dry_run: false # test mode that prevents creation or download of certs (default: false)
+apache2_ssl_vhosts: # apache mode only: SSL vhosts to install once certificates exist (default: [])
+- src: example-ssl.conf.j2 # template resolved from templates/apache2/vhosts/ next to the playbook
+  dest: example-ssl.conf # filename under /etc/apache2/sites-available/, symlinked into sites-enabled
 ```
 
 Notes
@@ -29,6 +32,10 @@ stored at `/etc/letsencrypt/live/example.com/cert.pem`.
 
 If using the `nginx` mode, this role should be run before nginx is installed as nginx will fail to start if the certs 
 are not present.
+
+If using the `apache` mode, apache2 must already be installed (e.g. via the `apache2` role). Vhost templates listed in
+`apache2_ssl_vhosts` are resolved relative to the consuming playbook, so they must live in `templates/apache2/vhosts/`
+next to it.
 
 If using the `dns-digitalocean` mode, you will need to set the `certbot_digitalocean_dns_token` var to an API token with
 all `domain` scopes. This can be generated at https://cloud.digitalocean.com/account/api/tokens/new.

--- a/roles/certbot/defaults/main.yml
+++ b/roles/certbot/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 certbot_certs: []
 certbot_dry_run: false
+apache2_ssl_vhosts: []

--- a/roles/certbot/handlers/main.yml
+++ b/roles/certbot/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart apache2
+  ansible.builtin.service:
+    name: apache2
+    enabled: true
+    state: restarted

--- a/roles/certbot/molecule/default/converge.yml
+++ b/roles/certbot/molecule/default/converge.yml
@@ -12,3 +12,43 @@
     certbot_mode: dns-digitalocean
   roles:
     - role: tborealis.roles.certbot
+
+# Apache mode applied standalone (no apache2 role in the play) to prove the
+# role ships everything it notifies (#124). The vhost listens on :80 because
+# no certificate can be issued in the container; the template/handler path it
+# exercises is the same one real SSL vhosts take.
+- name: Converge (apache mode)
+  hosts: all
+  become: true
+  vars_files:
+    - vars.yml
+  vars:
+    certbot_mode: apache
+    apache2_ssl_vhosts:
+      - src: molecule-ssl.conf.j2
+        dest: molecule-ssl.conf
+  pre_tasks:
+    - name: Install apache2
+      ansible.builtin.apt:
+        name: apache2
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: Create vhost document root
+      ansible.builtin.file:
+        path: /var/www/molecule-ssl
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Write vhost index page
+      ansible.builtin.copy:
+        content: "{{ certbot_test_vhost_marker }}\n"
+        dest: /var/www/molecule-ssl/index.html
+        owner: root
+        group: root
+        mode: "0644"
+  roles:
+    - role: tborealis.roles.certbot

--- a/roles/certbot/molecule/default/templates/apache2/vhosts/molecule-ssl.conf.j2
+++ b/roles/certbot/molecule/default/templates/apache2/vhosts/molecule-ssl.conf.j2
@@ -1,0 +1,4 @@
+<VirtualHost *:80>
+    ServerName {{ certbot_test_vhost_server_name }}
+    DocumentRoot /var/www/molecule-ssl
+</VirtualHost>

--- a/roles/certbot/molecule/default/vars.yml
+++ b/roles/certbot/molecule/default/vars.yml
@@ -3,3 +3,8 @@
 # NOT shaped like a real DigitalOcean token so secret scanning cannot mistake
 # it for one; no ACME requests are made because certbot_certs stays empty.
 certbot_digitalocean_dns_token: molecule-fake-do-token-0123456789
+
+# Apache-mode fixture shared by converge.yml, verify.yml and the vhost
+# template under templates/apache2/vhosts/.
+certbot_test_vhost_server_name: molecule-ssl.test
+certbot_test_vhost_marker: certbot-molecule-vhost-ok

--- a/roles/certbot/molecule/default/verify.yml
+++ b/roles/certbot/molecule/default/verify.yml
@@ -14,10 +14,11 @@
       register: certbot_verify_plugins
       changed_when: false
 
-    - name: Assert DigitalOcean DNS plugin is registered with certbot
+    - name: Assert DigitalOcean DNS and apache plugins are registered with certbot
       ansible.builtin.assert:
         that:
           - "'dns-digitalocean' in certbot_verify_plugins.stdout"
+          - "'apache' in certbot_verify_plugins.stdout"
 
     - name: Check renewal timer state # noqa: command-instead-of-module (service_facts does not report timer units)
       ansible.builtin.command: systemctl is-active certbot.timer
@@ -61,3 +62,27 @@
           - >-
             'dns_digitalocean_token = "' ~ certbot_digitalocean_dns_token ~ '"'
             in certbot_verify_credentials.content | b64decode
+
+    - name: Stat enabled SSL vhost symlink
+      ansible.builtin.stat:
+        path: /etc/apache2/sites-enabled/molecule-ssl.conf
+      register: certbot_verify_vhost_link
+
+    - name: Assert SSL vhost is enabled
+      ansible.builtin.assert:
+        that:
+          - certbot_verify_vhost_link.stat.islnk | default(false)
+          - certbot_verify_vhost_link.stat.lnk_source == '/etc/apache2/sites-available/molecule-ssl.conf'
+
+    - name: Probe the SSL vhost over HTTP
+      ansible.builtin.uri:
+        url: http://127.0.0.1/
+        headers:
+          Host: "{{ certbot_test_vhost_server_name }}"
+        return_content: true
+      register: certbot_verify_vhost_response
+
+    - name: Assert the vhost serves its document root
+      ansible.builtin.assert:
+        that:
+          - certbot_test_vhost_marker in certbot_verify_vhost_response.content


### PR DESCRIPTION
Ships the `Restart apache2` handler the apache tasks notify, defaults and documents `apache2_ssl_vhosts` (the apache2 role never defined it — it was always certbot's variable), and documents the playbook-relative `templates/apache2/vhosts/` contract. The molecule scenario now converges apache mode standalone and probes the installed vhost over HTTP.

Non-breaking; PATCH/MINOR.

Fixes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)