### PR TITLE
exim4: include the mailname in the local domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ flagged with **BREAKING** and require a MAJOR version bump.
 - **certbot:** apache mode now works standalone: the role ships the `Restart apache2`
   handler it notifies, defaults `apache2_ssl_vhosts` to `[]`, and documents the
   variable and its playbook-relative `templates/apache2/vhosts/` contract. (#124)
+- **exim4:** include the mailname in `dc_other_hostnames` so aliased local mail
+  (e.g. postmaster→root, qualified with `/etc/mailname`) stays routeable when the
+  mailname differs from the sender hostname. (#126)
 
 ## [5.1.0] - 2026-07-14
 

--- a/roles/exim4/README.md
+++ b/roles/exim4/README.md
@@ -7,4 +7,4 @@ Installs and configures Exim4 mail transfer agent.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `exim4_sender_hostname` | `{{ inventory_hostname }}` | Sender hostname for outgoing mail |
-| `mailname` | `{{ inventory_hostname }}` | System mail name |
+| `mailname` | `{{ inventory_hostname }}` | System mail name, written to `/etc/mailname` and included in exim's local domains so aliased local mail (e.g. postmaster) stays routeable |

--- a/roles/exim4/molecule/default/verify.yml
+++ b/roles/exim4/molecule/default/verify.yml
@@ -29,10 +29,11 @@
       register: exim4_verify_local_domains
       changed_when: false
 
-    - name: Assert the sender hostname is a local domain
+    - name: Assert the sender hostname and mailname are local domains
       ansible.builtin.assert:
         that:
           - exim4_sender_hostname in exim4_verify_local_domains.stdout
+          - mailname in exim4_verify_local_domains.stdout
 
     - name: Query the configured listening interfaces
       ansible.builtin.command: exim -bP local_interfaces
@@ -53,7 +54,7 @@
       ansible.builtin.assert:
         that:
           - "\"dc_eximconfig_configtype='internet'\" in exim4_verify_conf.content | b64decode"
-          - "\"dc_other_hostnames='\" ~ exim4_sender_hostname ~ \"'\" in exim4_verify_conf.content | b64decode"
+          - "\"dc_other_hostnames='\" ~ exim4_sender_hostname ~ \" ; \" ~ mailname ~ \"'\" in exim4_verify_conf.content | b64decode"
 
     - name: Read mailname
       ansible.builtin.slurp:
@@ -65,15 +66,15 @@
         that:
           - exim4_verify_mailname.content | b64decode == mailname ~ "\n"
 
-    # postmaster@localhost is not probeable here: its alias to root gets
-    # qualified with /etc/mailname, which the role does not add to the local
-    # domains, so the aliased address is unrouteable (role gap, tracked).
-    - name: Route mail to root as a local delivery smoke test
-      ansible.builtin.command: exim -bt root@localhost
+    # postmaster's alias to root gets qualified with /etc/mailname, so this
+    # routes only because the role includes the mailname in the local domains
+    # (the #126 regression).
+    - name: Route mail to postmaster as a local delivery smoke test
+      ansible.builtin.command: exim -bt postmaster@localhost
       register: exim4_verify_routing
       changed_when: false
 
-    - name: Assert root resolves to local delivery
+    - name: Assert postmaster resolves to local delivery
       ansible.builtin.assert:
         that:
           - "'transport = address_file' in exim4_verify_routing.stdout or 'router = local_user' in exim4_verify_routing.stdout"

--- a/roles/exim4/templates/etc/exim4/update-exim4.conf.conf.j2
+++ b/roles/exim4/templates/etc/exim4/update-exim4.conf.conf.j2
@@ -3,7 +3,7 @@
 #
 
 dc_eximconfig_configtype='internet'
-dc_other_hostnames='{{ exim4_sender_hostname }}'
+dc_other_hostnames='{{ [exim4_sender_hostname, mailname] | unique | join(' ; ') }}'
 dc_local_interfaces='127.0.0.1 ; ::1'
 dc_readhost=''
 dc_relay_domains=''


### PR DESCRIPTION
Aliased local mail (e.g. postmaster→root) is qualified with `/etc/mailname`, so when the mailname differed from the sender hostname the aliased address was rejected as unrouteable. `dc_other_hostnames` now carries both (deduplicated), matching the `dc_mailname_in_oh='true'` declaration already in the template. The molecule verify now probes `postmaster@localhost`, the case that used to fail.

Non-breaking; PATCH/MINOR.

Fixes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)