### PR TITLE
pgsql: document and validate postgres_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ flagged with **BREAKING** and require a MAJOR version bump.
 - **exim4:** include the mailname in `dc_other_hostnames` so aliased local mail
   (e.g. postmaster→root, qualified with `/etc/mailname`) stays routeable when the
   mailname differs from the sender hostname. (#126)
+- **pgsql:** `postgres_version` is now documented as required and validated
+  against the majors the role ships config templates for (12, 13, 15), failing
+  early with a clear message instead of a template-not-found error. The
+  `postgres_version` requirement is also documented for `pgsql_client`. (#128)
 
 ## [5.1.0] - 2026-07-14
 

--- a/roles/pgsql/README.md
+++ b/roles/pgsql/README.md
@@ -6,6 +6,7 @@ Installs and configures PostgreSQL server.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `postgres_version` | — (required) | PostgreSQL major version to install; must be one the role ships config templates for (12, 13 or 15) |
 | `postgres_databases` | `[]` | Databases to create |
 | `postgres_users` | `[]` | Users to create |
 | `postgres_schemas` | `[]` | Schemas to create (keys: `db`, `name`, `owner`) |

--- a/roles/pgsql/tasks/main.yml
+++ b/roles/pgsql/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Assert postgres_version is a supported major
+  ansible.builtin.assert:
+    that:
+      - postgres_version is defined
+      - postgres_version | string in pgsql_supported_versions | map('string') | list
+    fail_msg: >-
+      postgres_version must be set to a PostgreSQL major the role ships config
+      templates for ({{ pgsql_supported_versions | join(', ') }}).
+
 - name: Install deb822 dependency
   ansible.builtin.apt:
     pkg: python3-debian

--- a/roles/pgsql/vars/main.yml
+++ b/roles/pgsql/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# Majors the role ships postgresql-<v>.conf.j2 / pg_hba-<v>.conf.j2 templates for.
+pgsql_supported_versions: [12, 13, 15]

--- a/roles/pgsql_client/README.md
+++ b/roles/pgsql_client/README.md
@@ -6,4 +6,5 @@ Installs PostgreSQL client tools.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `postgres_version` | — (required) | PostgreSQL client major version to install (any major available in the pgdg apt repository) |
 | `postgres_default_packages` | See defaults | PostgreSQL client packages to install |


### PR DESCRIPTION
Documents `postgres_version` as required in the pgsql and pgsql_client READMEs and asserts it against the majors the role ships config templates for (12, 13, 15), failing early with a clear message instead of a template-not-found error.

The issue's dead-code items (remove-postgres task files, unused restart handler, `postgres_` prefix) are deferred to the next major release, so this closes only part of the ticket (commit uses `Refs #128`). Follow-up for newer PostgreSQL: #141.

Non-breaking; PATCH/MINOR.

Refs #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)