### PR TITLE
nvm, node: make corepack and global-package tasks idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ flagged with **BREAKING** and require a MAJOR version bump.
   against the majors the role ships config templates for (12, 13, 15), failing
   early with a clear message instead of a template-not-found error. The
   `postgres_version` requirement is also documented for `pgsql_client`. (#128)
+- **nvm, node:** the corepack-enable and nvm global-package tasks reported changed on
+  every run; they now probe the existing shims/packages first, so converges with those
+  options enabled are idempotent. The nvm installer is bumped to v0.40.5 and the
+  README no longer references a nonexistent archive checksum. (#131)
 
 ## [5.1.0] - 2026-07-14
 

--- a/roles/node/molecule/default/converge.yml
+++ b/roles/node/molecule/default/converge.yml
@@ -5,5 +5,7 @@
   vars:
     # Matches the version the apt_keys manifest pins for live key verification.
     node_version: 22
+    # Exercises the corepack path so idempotence covers it (#131).
+    node_corepack_enable: true
   roles:
     - role: tborealis.roles.node

--- a/roles/node/molecule/default/verify.yml
+++ b/roles/node/molecule/default/verify.yml
@@ -23,6 +23,22 @@
         that:
           - "node_verify_npm.stdout is match('^[0-9]+\\.[0-9]+\\.[0-9]+$')"
 
+    # Corepack shims are created next to the node binary; invoking them would
+    # download yarn/pnpm at run time, so assert their presence instead.
+    - name: Stat the corepack shims
+      ansible.builtin.stat:
+        path: "/usr/bin/{{ item }}"
+      register: node_verify_corepack_shims
+      with_items: [yarn, pnpm]
+
+    - name: Assert the corepack shims are installed
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+      with_items: "{{ node_verify_corepack_shims.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
     - name: Check the nodejs package origin
       ansible.builtin.command: apt-cache policy nodejs
       register: node_verify_policy

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -31,12 +31,24 @@
     update_cache: true
     cache_valid_time: 3600
 
+- name: Check corepack shims
+  ansible.builtin.command: >-
+    bash -c 'bin="$(dirname "$(command -v corepack)")";
+    for shim in {{ node_corepack_enable if node_corepack_enable is string else 'yarn pnpm' }};
+    do test -e "$bin/$shim" || exit 1; done'
+  register: node_corepack_shims
+  failed_when: false
+  changed_when: false
+  when: node_corepack_enable is not false
+
 - name: Enable package managers via corepack
   ansible.builtin.command: >-
     corepack enable
     {{ node_corepack_enable if node_corepack_enable is string else '' }}
   changed_when: true
-  when: node_corepack_enable is not false
+  when:
+    - node_corepack_enable is not false
+    - node_corepack_shims.rc != 0
 
 - name: Write .npmrc
   ansible.builtin.template:

--- a/roles/nvm/README.md
+++ b/roles/nvm/README.md
@@ -34,5 +34,6 @@ be attempted using `user` but need root permissions, resulting in a failure.
 Updating
 --------
 
-When updating the NVM version (see defaults/main.yml) you need to all update the checksum of the
-archive.
+To update NVM, set `nvm_version` (see defaults/main.yml) to the new release tag. The installer
+is fetched from that tag on GitHub; users whose installed nvm version differs are re-run through
+the installer.

--- a/roles/nvm/defaults/main.yml
+++ b/roles/nvm/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-nvm_version: 0.39.7
+nvm_version: 0.40.5
 nvm_config: []

--- a/roles/nvm/molecule/default/converge.yml
+++ b/roles/nvm/molecule/default/converge.yml
@@ -10,6 +10,8 @@
         default_version: "{{ nvm_molecule_node_major }}"
         versions:
           - version: "{{ nvm_molecule_node_major }}"
-            global_packages: []
+            corepack_enable: true
+            global_packages:
+              - "{{ nvm_molecule_global_package }}"
   roles:
     - role: tborealis.roles.nvm

--- a/roles/nvm/molecule/default/vars.yml
+++ b/roles/nvm/molecule/default/vars.yml
@@ -2,3 +2,6 @@
 # Shared by prepare.yml, converge.yml and verify.yml.
 nvm_molecule_user: molecule
 nvm_molecule_node_major: 22
+# Tiny dependency-free package with a CLI, used to exercise the
+# global-packages and corepack paths (#131).
+nvm_molecule_global_package: semver

--- a/roles/nvm/molecule/default/verify.yml
+++ b/roles/nvm/molecule/default/verify.yml
@@ -36,3 +36,34 @@
       ansible.builtin.assert:
         that:
           - nvm_verify_node_version.stdout.startswith('v' ~ nvm_molecule_node_major ~ '.')
+
+    - name: Run the installed global package's CLI
+      become_user: "{{ nvm_molecule_user }}"
+      become: true
+      ansible.builtin.shell: . "$HOME/.nvm/nvm.sh" && {{ nvm_molecule_global_package }} 1.2.3
+      args:
+        executable: /bin/bash
+      register: nvm_verify_global_package
+      changed_when: false
+
+    - name: Assert the global package works
+      ansible.builtin.assert:
+        that:
+          - nvm_verify_global_package.stdout == '1.2.3'
+
+    # Corepack shims are created next to the version's node binary; invoking
+    # them would download yarn/pnpm at run time, so assert their presence.
+    - name: Check the corepack yarn shim location
+      become_user: "{{ nvm_molecule_user }}"
+      become: true
+      ansible.builtin.shell: . "$HOME/.nvm/nvm.sh" && command -v yarn && command -v pnpm
+      args:
+        executable: /bin/bash
+      register: nvm_verify_corepack_shims
+      changed_when: false
+
+    - name: Assert the corepack shims live in the nvm version's bin dir
+      ansible.builtin.assert:
+        that:
+          - "'/.nvm/versions/node/' in nvm_verify_corepack_shims.stdout_lines[0]"
+          - "'/.nvm/versions/node/' in nvm_verify_corepack_shims.stdout_lines[1]"

--- a/roles/nvm/tasks/per_version.yml
+++ b/roles/nvm/tasks/per_version.yml
@@ -5,14 +5,34 @@
   changed_when: "'is already installed' not in nvm_install_result.stderr"
   when: nvm_user_config_version.version != 'system'
 
+- name: "Check corepack shims for Node version {{ nvm_user_config_version.version }}"
+  ansible.builtin.command: >-
+    bash -ic 'bin="$(dirname "$(nvm which {{ nvm_user_config_version.version }})")";
+    for shim in {{ nvm_user_config_version.corepack_enable if nvm_user_config_version.corepack_enable is string else 'yarn pnpm' }};
+    do test -e "$bin/$shim" || exit 1; done'
+  register: nvm_corepack_shims
+  failed_when: false
+  changed_when: false
+  when: nvm_user_config_version.corepack_enable|default(false) is not false
+
 - name: "Enable package managers for Node version {{ nvm_user_config_version.version }}"
   ansible.builtin.command: >-
     bash -ic "nvm exec {{ nvm_user_config_version.version }} corepack enable
     {{ nvm_user_config_version.corepack_enable if nvm_user_config_version.corepack_enable is string else '' }}"
   changed_when: true
-  when: nvm_user_config_version.corepack_enable|default(false) is not false
+  when:
+    - nvm_user_config_version.corepack_enable|default(false) is not false
+    - nvm_corepack_shims.rc != 0
+
+- name: "List global packages for Node version {{ nvm_user_config_version.version }}"
+  ansible.builtin.command: 'bash -ic "nvm exec --silent {{ nvm_user_config_version.version }} npm ls -g --depth=0 --parseable"'
+  register: nvm_global_packages
+  failed_when: false
+  changed_when: false
+  when: nvm_user_config_version.global_packages | length > 0
 
 - name: "Install global packages for Node version {{ nvm_user_config_version.version }}"
-  ansible.builtin.command: 'bash -ic "nvm exec {{ nvm_user_config_version.version }}  npm install -g --production {{ item }}"'
+  ansible.builtin.command: 'bash -ic "nvm exec {{ nvm_user_config_version.version }} npm install -g --production {{ item }}"'
   changed_when: true
   with_items: "{{ nvm_user_config_version.global_packages }}"
+  when: "'/node_modules/' ~ (item | regex_replace('@[^/@]+$', '')) not in nvm_global_packages.stdout"


### PR DESCRIPTION
The corepack-enable tasks ran with `changed_when: true` on every converge; they are now guarded by a probe for the shims corepack creates next to the node binary. nvm's global-package installs likewise check `npm ls -g` output first. Both molecule scenarios enable these options so the idempotence stage covers them. Also bumps the pinned nvm installer to v0.40.5 and drops the README's reference to a nonexistent archive checksum.

Non-breaking; PATCH/MINOR.

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)