### PR TITLE
mailpit: new role replacing the deprecated mailhog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+### Added
+
+- **mailpit:** new role installing [Mailpit](https://github.com/axllent/mailpit), the
+  maintained MailHog successor (same default ports: SMTP 1025, web UI/API 8025), with
+  a pinned version, per-architecture sha256 checksums (amd64/arm64), a correctly-moded
+  systemd unit, and a daemon-reloading restart handler. Replaces the deprecated
+  `mailhog` role. (#130)
+
 ### Fixed
 
 - **certbot:** apache mode now works standalone: the role ships the `Restart apache2`
@@ -27,6 +35,12 @@ flagged with **BREAKING** and require a MAJOR version bump.
   every run; they now probe the existing shims/packages first, so converges with those
   options enabled are idempotent. The nvm installer is bumped to v0.40.5 and the
   README no longer references a nonexistent archive checksum. (#131)
+
+### Deprecated
+
+- **mailhog:** upstream is archived/unmaintained, the binary download is unverified
+  and amd64-only. Use the new `mailpit` role instead; `mailhog` will be removed in the
+  next major release. (#130)
 
 ## [5.1.0] - 2026-07-14
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Reference the roles using the collection namespace:
 | [exim4](roles/exim4/README.md) | Exim4 mail transfer agent |
 | [git](roles/git/README.md) | Git installation and configuration |
 | [gpg](roles/gpg/README.md) | GPG key management |
-| [mailhog](roles/mailhog/README.md) | MailHog email testing |
+| [mailhog](roles/mailhog/README.md) | MailHog email testing (deprecated, use mailpit) |
+| [mailpit](roles/mailpit/README.md) | Mailpit email testing |
 | [mysql](roles/mysql/README.md) | MySQL server |
 | [new_relic](roles/new_relic/README.md) | New Relic PHP agent |
 | [nginx](roles/nginx/README.md) | Nginx web server |

--- a/roles/mailhog/README.md
+++ b/roles/mailhog/README.md
@@ -1,5 +1,9 @@
 # mailhog
 
+**Deprecated:** upstream MailHog has been archived and unmaintained since ~2020; the
+binary download is unverified and amd64-only. Use the [`mailpit`](../mailpit/README.md)
+role instead (same default ports). This role will be removed in the next major release.
+
 Installs MailHog for email testing in development environments.
 
 ## Role Variables

--- a/roles/mailpit/README.md
+++ b/roles/mailpit/README.md
@@ -1,0 +1,22 @@
+# mailpit
+
+Installs [Mailpit](https://github.com/axllent/mailpit) for email testing in development
+environments. Mailpit is the maintained successor to MailHog and serves the same
+purpose with the same default ports: SMTP capture on 1025 and a web UI/API on 8025.
+
+This role replaces the deprecated `mailhog` role.
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `mailpit_version` | See defaults | Mailpit release to install |
+| `mailpit_checksums` | See defaults | sha256 checksums of the release tarball per architecture (`amd64`, `arm64`) |
+| `mailpit_install_dir` | `/opt/mailpit` | Installation directory |
+| `mailpit_user` | `mailpit` | User to run Mailpit as |
+
+## Updating
+
+Upstream publishes no checksum manifest, so when bumping `mailpit_version` update both
+`mailpit_checksums` entries from the release tarballs
+(`https://github.com/axllent/mailpit/releases/download/v<version>/mailpit-linux-<arch>.tar.gz`).

--- a/roles/mailpit/defaults/main.yml
+++ b/roles/mailpit/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+mailpit_version: 1.30.4
+# Upstream publishes no checksum manifest; these are pinned from the release
+# tarballs. Update both when bumping mailpit_version (see README).
+mailpit_checksums:
+  amd64: "sha256:e9c104154c22b83ac4c7d19f9d665a5c933585a3caafcd790805d732fa8d03fb"
+  arm64: "sha256:27f6556c4d922d5ee2afb8b85a799dc2445b894782e7ec0196a566598d107221"
+mailpit_install_dir: /opt/mailpit
+mailpit_user: mailpit

--- a/roles/mailpit/handlers/main.yml
+++ b/roles/mailpit/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart mailpit
+  ansible.builtin.systemd_service:
+    name: mailpit.service
+    daemon_reload: true
+    enabled: true
+    state: restarted

--- a/roles/mailpit/molecule/default/converge.yml
+++ b/roles/mailpit/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: tborealis.roles.mailpit

--- a/roles/mailpit/molecule/default/molecule.yml
+++ b/roles/mailpit/molecule/default/molecule.yml
@@ -1,0 +1,2 @@
+---
+# Inherits everything from .config/molecule/config.yml.

--- a/roles/mailpit/molecule/default/verify.yml
+++ b/roles/mailpit/molecule/default/verify.yml
@@ -1,0 +1,75 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  vars:
+    mailpit_verify_subject: molecule-round-trip-test
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert mailpit service is running
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['mailpit.service'].state == 'running'
+
+    - name: Wait for the SMTP port to accept connections
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 1025
+        timeout: 30
+
+    - name: Request the web UI
+      ansible.builtin.uri:
+        url: http://127.0.0.1:8025/
+        return_content: true
+      register: mailpit_verify_ui
+
+    - name: Assert the web UI serves Mailpit
+      ansible.builtin.assert:
+        that:
+          - mailpit_verify_ui.status == 200
+          - "'Mailpit' in mailpit_verify_ui.content"
+
+    - name: Send a test mail through the SMTP port
+      community.general.mail:
+        host: 127.0.0.1
+        port: 1025
+        secure: never
+        from: molecule@example.com
+        to: inbox@example.com
+        subject: "{{ mailpit_verify_subject }}"
+        body: Functional SMTP round-trip sent by molecule verify.
+
+    - name: Query the messages API
+      ansible.builtin.uri:
+        url: http://127.0.0.1:8025/api/v1/messages
+        return_content: true
+      register: mailpit_verify_messages
+
+    - name: Assert the test mail was captured
+      ansible.builtin.assert:
+        that:
+          - mailpit_verify_messages.json.total | int >= 1
+          - mailpit_verify_messages.json.messages[0].Subject == mailpit_verify_subject
+
+    - name: Read the systemd unit
+      ansible.builtin.slurp:
+        src: /lib/systemd/system/mailpit.service
+      register: mailpit_verify_unit
+
+    - name: Assert the unit runs the installed binary as the mailpit user
+      ansible.builtin.assert:
+        that:
+          - "'ExecStart=/opt/mailpit/mailpit' in mailpit_verify_unit.content | b64decode"
+          - "'User=mailpit' in mailpit_verify_unit.content | b64decode"
+
+    - name: Stat the systemd unit
+      ansible.builtin.stat:
+        path: /lib/systemd/system/mailpit.service
+      register: mailpit_verify_unit_stat
+
+    - name: Assert the unit is not executable
+      ansible.builtin.assert:
+        that:
+          - mailpit_verify_unit_stat.stat.mode == '0644'

--- a/roles/mailpit/tasks/main.yml
+++ b/roles/mailpit/tasks/main.yml
@@ -1,0 +1,68 @@
+---
+- name: Assert the architecture is supported
+  ansible.builtin.assert:
+    that: ansible_facts['architecture'] in mailpit_architecture_map
+    fail_msg: "The role pins checksums for {{ mailpit_architecture_map.keys() | join(', ') }} only."
+
+- name: Create mailpit user
+  ansible.builtin.user:
+    name: "{{ mailpit_user }}"
+    createhome: false
+    shell: /bin/false
+    system: true
+    password: "*"
+
+- name: Create mailpit directory
+  ansible.builtin.file:
+    path: "{{ mailpit_install_dir }}"
+    owner: root
+    group: root
+    state: directory
+    mode: "0755"
+
+- name: Check the installed mailpit version
+  ansible.builtin.command: "{{ mailpit_install_dir }}/mailpit version"
+  register: mailpit_installed
+  failed_when: false
+  changed_when: false
+
+- name: Install mailpit
+  when: mailpit_installed.rc != 0 or ('v' ~ mailpit_version) not in mailpit_installed.stdout
+  vars:
+    mailpit_architecture: "{{ mailpit_architecture_map[ansible_facts['architecture']] }}"
+  block:
+    - name: Download the mailpit release
+      ansible.builtin.get_url:
+        url: "https://github.com/axllent/mailpit/releases/download/v{{ mailpit_version }}/mailpit-linux-{{ mailpit_architecture }}.tar.gz"
+        dest: /var/tmp/mailpit.tar.gz
+        checksum: "{{ mailpit_checksums[mailpit_architecture] }}"
+        mode: "0644"
+
+    - name: Unpack mailpit
+      ansible.builtin.unarchive:
+        src: /var/tmp/mailpit.tar.gz
+        dest: "{{ mailpit_install_dir }}"
+        remote_src: true
+        owner: root
+        group: root
+      notify: Restart mailpit
+
+    - name: Clean up the release download
+      ansible.builtin.file:
+        path: /var/tmp/mailpit.tar.gz
+        state: absent
+
+- name: Install mailpit service
+  ansible.builtin.template:
+    src: mailpit.service.j2
+    dest: /lib/systemd/system/mailpit.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart mailpit
+
+- name: Enable mailpit service
+  ansible.builtin.systemd_service:
+    name: mailpit.service
+    enabled: true
+    state: started

--- a/roles/mailpit/templates/mailpit.service.j2
+++ b/roles/mailpit/templates/mailpit.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Mailpit Email Catcher
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={{ mailpit_install_dir }}/mailpit
+User={{ mailpit_user }}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/mailpit/vars/main.yml
+++ b/roles/mailpit/vars/main.yml
@@ -1,0 +1,4 @@
+---
+mailpit_architecture_map:
+  x86_64: amd64
+  aarch64: arm64


### PR DESCRIPTION
Step 1 of the MailHog→Mailpit switch: adds a `mailpit` role (pinned v1.30.4, per-arch sha256 checksums, 0644 unit, daemon-reloading restart handler, explicit started+enabled task) with a functional SMTP round-trip molecule scenario, and deprecates `mailhog` (README banner + changelog). Step 2 — removing mailhog and migrating legacy installs — is a separate BREAKING branch held for the next major release.

Non-breaking (deprecation only); MINOR.

Fixes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)