### PR TITLE
mysql, apt_keys: drop undefined {{ item }} from looped task names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ### Fixed
 
+- **mysql:** removed the undefined `{{ item }}` reference from the looped
+  root-user-removal task name, fixing the "'item' is undefined" template warning
+  emitted on every run.
+- **apt_keys:** same fix for two looped task names in the Molecule verify playbook.
 - **certbot:** apache mode now works standalone: the role ships the `Restart apache2`
   handler it notifies, defaults `apache2_ssl_vhosts` to `[]`, and documents the
   variable and its playbook-relative `templates/apache2/vhosts/` contract. (#124)

--- a/roles/apt_keys/molecule/default/verify.yml
+++ b/roles/apt_keys/molecule/default/verify.yml
@@ -26,7 +26,7 @@
           - apt_keys_verify_dir.stat.gr_name == 'root'
           - apt_keys_verify_dir.stat.mode == '0755'
 
-    - name: Stat keyring for {{ item.name }}
+    - name: Stat manifest keyrings
       ansible.builtin.stat:
         path: "{{ item.dest }}"
       loop: "{{ apt_keys_verify_defaults.apt_keys_keyrings }}"
@@ -46,7 +46,7 @@
       loop_control:
         label: "{{ item.item.name }}"
 
-    - name: Parse installed keyring {{ item }}
+    - name: Parse installed keyrings
       ansible.builtin.command: gpg --show-keys --with-colons {{ item }}
       changed_when: false
       loop: "{{ apt_keys_verify_defaults.apt_keys_keyrings | map(attribute='dest') | unique | list }}"

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -136,7 +136,7 @@
     check_implicit_admin: true
     column_case_sensitive: true
 
-- name: Remove redundant root user for {{ item }}
+- name: Remove redundant root users
   ansible.mysql.mysql_user:
     name: root
     host: "{{ item }}"


### PR DESCRIPTION
## Summary

Ansible templates task names once, **before** the loop starts, so referencing `item` in a looping task's name emits an `'item' is undefined` template warning on every run (seen in production on the mysql role). The per-item value is already shown by the `(item=...)` loop suffix / `loop_control` label, so the names shouldn't reference `item` at all.

Fixes all three instances in the repo:

- **mysql:** `Remove redundant root user for {{ item }}` → `Remove redundant root users`
- **apt_keys** (Molecule verify): `Parse installed keyring {{ item }}` → `Parse installed keyrings`, `Stat keyring for {{ item.name }}` → `Stat manifest keyrings`

## Testing

- `make lint` passes
- `make test ROLE=mysql` and `make test ROLE=apt_keys` (bookworm + trixie) pass with zero template warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)