### PR TITLE
nginx, apache2, supervisor, rabbitmq, exim4: explicitly enable and start services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ### Fixed
 
+- **nginx, apache2, supervisor, rabbitmq, exim4:** the roles now explicitly enable
+  and start their services instead of relying on Debian's start-on-install policy
+  and config-change handlers, so a re-run recovers a stopped or disabled unit. (#132)
 - **mysql:** removed the undefined `{{ item }}` reference from the looped
   root-user-removal task name, fixing the "'item' is undefined" template warning
   emitted on every run.

--- a/roles/apache2/molecule/default/verify.yml
+++ b/roles/apache2/molecule/default/verify.yml
@@ -8,10 +8,11 @@
     - name: Gather service facts
       ansible.builtin.service_facts:
 
-    - name: Assert apache2 service is running
+    - name: Assert apache2 service is enabled and running
       ansible.builtin.assert:
         that:
           - ansible_facts.services['apache2.service'].state == 'running'
+          - ansible_facts.services['apache2.service'].status in ['enabled', 'generated']
 
     - name: Validate Apache configuration # noqa: command-instead-of-module (functional check of the deployed config)
       ansible.builtin.command: apache2ctl configtest

--- a/roles/apache2/tasks/main.yml
+++ b/roles/apache2/tasks/main.yml
@@ -68,3 +68,9 @@
     state: link
   with_items: "{{ apache2_vhosts }}"
   notify: Restart apache2
+
+- name: Enable and start Apache2
+  ansible.builtin.systemd:
+    name: apache2
+    enabled: true
+    state: started

--- a/roles/exim4/tasks/main.yml
+++ b/roles/exim4/tasks/main.yml
@@ -23,3 +23,9 @@
     group: root
     mode: "0644"
   notify: Restart exim4
+
+- name: Enable and start exim4
+  ansible.builtin.systemd:
+    name: exim4
+    enabled: true
+    state: started

--- a/roles/nginx/molecule/default/verify.yml
+++ b/roles/nginx/molecule/default/verify.yml
@@ -8,10 +8,11 @@
     - name: Gather service facts
       ansible.builtin.service_facts:
 
-    - name: Assert nginx service is running
+    - name: Assert nginx service is enabled and running
       ansible.builtin.assert:
         that:
           - ansible_facts.services['nginx.service'].state == 'running'
+          - ansible_facts.services['nginx.service'].status in ['enabled', 'generated']
 
     - name: Validate nginx configuration
       ansible.builtin.command: nginx -t

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -128,3 +128,9 @@
     mode: "0644"
   with_items: "{{ nginx_vhosts }}"
   notify: Reload nginx
+
+- name: Enable and start nginx
+  ansible.builtin.systemd:
+    name: nginx
+    enabled: true
+    state: started

--- a/roles/rabbitmq/molecule/default/verify.yml
+++ b/roles/rabbitmq/molecule/default/verify.yml
@@ -8,10 +8,11 @@
     - name: Gather service facts
       ansible.builtin.service_facts:
 
-    - name: Assert RabbitMQ service is running
+    - name: Assert RabbitMQ service is enabled and running
       ansible.builtin.assert:
         that:
           - ansible_facts.services['rabbitmq-server.service'].state == 'running'
+          - ansible_facts.services['rabbitmq-server.service'].status in ['enabled', 'generated']
 
     - name: Check broker status
       ansible.builtin.command: rabbitmqctl status

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -70,6 +70,12 @@
     update_cache: true
     cache_valid_time: 3600
 
+- name: Enable and start RabbitMQ
+  ansible.builtin.systemd:
+    name: rabbitmq-server
+    enabled: true
+    state: started
+
 - name: Install RabbitMQ management plugin
   community.rabbitmq.rabbitmq_plugin:
     names: rabbitmq_management

--- a/roles/supervisor/molecule/default/verify.yml
+++ b/roles/supervisor/molecule/default/verify.yml
@@ -6,10 +6,11 @@
     - name: Gather service facts
       ansible.builtin.service_facts:
 
-    - name: Assert supervisor service is running
+    - name: Assert supervisor service is enabled and running
       ansible.builtin.assert:
         that:
           - ansible_facts.services['supervisor.service'].state == 'running'
+          - ansible_facts.services['supervisor.service'].status in ['enabled', 'generated']
 
     - name: Query the test program status # noqa: command-instead-of-module (exercises supervisorctl against the live daemon)
       ansible.builtin.command: supervisorctl status sleeper

--- a/roles/supervisor/tasks/main.yml
+++ b/roles/supervisor/tasks/main.yml
@@ -42,3 +42,9 @@
     mode: "0640"
   with_items: "{{ supervisor_configs }}"
   notify: Update supervisor
+
+- name: Enable and start supervisor
+  ansible.builtin.systemd:
+    name: supervisor
+    enabled: true
+    state: started


### PR DESCRIPTION
Closes #132.

The five roles relied on Debian's start-on-install policy and on config-change handlers, so a fully idempotent re-run against a stopped or disabled service left it down. Each role now has an explicit `enabled: true` + `state: started` task (the redis pattern):

- nginx, apache2, supervisor, exim4: at the end of the task flow.
- rabbitmq: immediately after package install, before the `community.rabbitmq.*` tasks that need a running broker.

The molecule verify playbooks now also assert the unit is enabled (exim4 already did). All five roles pass `make test` on both releases.

Non-breaking; MINOR-level fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)