### PR TITLE
chrome: t64 dependency names on trixie, resolve version before installing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ flagged with **BREAKING** and require a MAJOR version bump.
 - **nginx, apache2, supervisor, rabbitmq, exim4:** the roles now explicitly enable
   and start their services instead of relying on Debian's start-on-install policy
   and config-change handlers, so a re-run recovers a stopped or disabled unit. (#132)
+- **chrome:** system dependencies now use the t64 package names on trixie instead of
+  relying on virtual-package resolution, and the target version is resolved from the
+  Chrome for Testing channel data before installing, so the browser is only downloaded
+  when the installed version differs (previously `npx @puppeteer/browsers` ran on
+  every play, and a stable promotion between runs broke idempotence).
+  Same for chromedriver. (#133)
 - **mysql:** removed the undefined `{{ item }}` reference from the looped
   root-user-removal task name, fixing the "'item' is undefined" template warning
   emitted on every run.

--- a/roles/chrome/README.md
+++ b/roles/chrome/README.md
@@ -6,8 +6,8 @@ Installs Google Chrome and optionally ChromeDriver using Puppeteer's browser ins
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `chrome_version` | `stable` | Chrome version to install |
-| `chrome_chromedriver_version` | `{{ chrome_version }}` | ChromeDriver version to install |
+| `chrome_version` | `stable` | Release channel (`stable`, `beta`, `dev`, `canary`) or exact version to install |
+| `chrome_chromedriver_version` | `{{ chrome_version }}` | ChromeDriver channel or exact version to install |
 | `chrome_install_chromedriver` | `false` | Whether to install ChromeDriver |
 | `chrome_remove_system_chrome` | `false` | Remove system-installed Chrome first |
-| `chrome_system_dependencies` | See defaults | System dependencies for Chrome |
+| `chrome_system_dependencies` | See defaults | System dependencies for Chrome (packages renamed per Debian release are appended automatically) |

--- a/roles/chrome/defaults/main.yml
+++ b/roles/chrome/defaults/main.yml
@@ -5,20 +5,16 @@ chrome_install_chromedriver: false
 chrome_remove_system_chrome: false
 
 # See https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/debian/dist_package_versions.json
+# Packages whose name differs per Debian release live in
+# chrome_release_dependencies (vars/main.yml) and are appended to this list.
 chrome_system_dependencies:
   - unzip # @puppeteer/browsers needs it to extract the chrome archive
-  - libasound2
-  - libatk-bridge2.0-0
-  - libatk1.0-0
-  - libatspi2.0-0
   - libc6
   - libcairo2
-  - libcups2
   - libdbus-1-3
   - libdrm2
   - libexpat1
   - libgbm1
-  - libglib2.0-0
   - libnspr4
   - libnss3
   - libpango-1.0-0

--- a/roles/chrome/molecule/default/converge.yml
+++ b/roles/chrome/molecule/default/converge.yml
@@ -1,9 +1,18 @@
 ---
-# Defaults install the current Chrome stable, which is the real contract.
+# Installs the Chrome stable that prepare.yml resolved and pinned, so the
+# idempotence re-run targets the same version even if Google promotes a new
+# stable between the two converges. Real playbooks use the default channel.
 # chrome_install_chromedriver stays at its default (false) to keep the
 # scenario to one ~150 MB browser download.
 - name: Converge
   hosts: all
   become: true
+  pre_tasks:
+    - name: Read the pinned chrome version
+      ansible.builtin.slurp:
+        src: /var/tmp/molecule-chrome-version
+      register: chrome_pinned_version
   roles:
     - role: tborealis.roles.chrome
+      vars:
+        chrome_version: "{{ chrome_pinned_version.content | b64decode | trim }}"

--- a/roles/chrome/molecule/default/prepare.yml
+++ b/roles/chrome/molecule/default/prepare.yml
@@ -9,3 +9,17 @@
     node_version: 22
   roles:
     - role: tborealis.roles.node
+  tasks:
+    # Pin the current stable so converge and idempotence install the same
+    # version even if Google promotes a new stable mid-run.
+    - name: Resolve the current chrome stable version
+      ansible.builtin.uri:
+        url: https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json
+        return_content: true
+      register: chrome_prepare_versions
+
+    - name: Pin the resolved version for converge
+      ansible.builtin.copy:
+        content: "{{ chrome_prepare_versions.json.channels.Stable.version }}\n"
+        dest: /var/tmp/molecule-chrome-version
+        mode: "0644"

--- a/roles/chrome/tasks/chromedriver.yml
+++ b/roles/chrome/tasks/chromedriver.yml
@@ -5,16 +5,29 @@
   changed_when: false
   failed_when: false
 
+- name: Resolve the chromedriver channel version
+  ansible.builtin.uri:
+    url: https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json
+    return_content: true
+  register: chromedriver_channel_versions
+  when: chrome_chromedriver_version in chrome_release_channels
+
+- name: Set the chromedriver target version
+  ansible.builtin.set_fact:
+    chromedriver_target_version: >-
+      {{ chromedriver_channel_versions.json.channels[chrome_chromedriver_version | capitalize].version
+         if chrome_chromedriver_version in chrome_release_channels else chrome_chromedriver_version }}
+
 - name: Install chromedriver
-  ansible.builtin.command: "npx --yes @puppeteer/browsers install chromedriver@{{ chrome_chromedriver_version }} --path /opt"
+  ansible.builtin.command: "npx --yes @puppeteer/browsers install chromedriver@{{ chromedriver_target_version }} --path /opt"
   register: chromedriver_install_result
-  changed_when: >
-    chromedriver_current_version.rc != 0 or
-    (chromedriver_install_result.stdout | regex_search('chromedriver@([\\d.]+)', '\\1') | first) not in chromedriver_current_version.stdout
+  changed_when: true
+  when: chromedriver_current_version.rc != 0 or chromedriver_target_version not in chromedriver_current_version.stdout
 
 - name: Process chromedriver path
   ansible.builtin.set_fact:
     chromedriver_path: "{{ chromedriver_install_result.stdout | regex_search('chromedriver@[\\d.]+ (.+)', '\\1') | first }}"
+  when: chromedriver_install_result is not skipped
 
 - name: Link chromedriver
   ansible.builtin.file:
@@ -22,3 +35,4 @@
     dest: /usr/local/bin/chromedriver
     state: link
     force: true
+  when: chromedriver_install_result is not skipped

--- a/roles/chrome/tasks/main.yml
+++ b/roles/chrome/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Install chrome system dependencies
   ansible.builtin.apt:
-    pkg: "{{ chrome_system_dependencies }}"
+    pkg: "{{ chrome_system_dependencies + chrome_release_dependencies[ansible_facts['distribution_release']] }}"
     state: present
     update_cache: true
     cache_valid_time: 3600
@@ -16,16 +16,29 @@
   changed_when: false
   failed_when: false
 
+- name: Resolve the chrome channel version
+  ansible.builtin.uri:
+    url: https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json
+    return_content: true
+  register: chrome_channel_versions
+  when: chrome_version in chrome_release_channels
+
+- name: Set the chrome target version
+  ansible.builtin.set_fact:
+    chrome_target_version: >-
+      {{ chrome_channel_versions.json.channels[chrome_version | capitalize].version
+         if chrome_version in chrome_release_channels else chrome_version }}
+
 - name: Install chrome
-  ansible.builtin.command: "npx --yes @puppeteer/browsers install chrome@{{ chrome_version }} --path /opt"
+  ansible.builtin.command: "npx --yes @puppeteer/browsers install chrome@{{ chrome_target_version }} --path /opt"
   register: chrome_install_result
-  changed_when: >
-    chrome_current_version.rc != 0 or
-    (chrome_install_result.stdout | regex_search('chrome@([\\d.]+)', '\\1') | first) not in chrome_current_version.stdout
+  changed_when: true
+  when: chrome_current_version.rc != 0 or chrome_target_version not in chrome_current_version.stdout
 
 - name: Process chrome path
   ansible.builtin.set_fact:
     chrome_path: "{{ chrome_install_result.stdout | regex_search('chrome@[\\d.]+ (.+)', '\\1') | first }}"
+  when: chrome_install_result is not skipped
 
 - name: Link chrome
   ansible.builtin.file:
@@ -33,6 +46,7 @@
     dest: /usr/local/bin/google-chrome
     state: link
     force: true
+  when: chrome_install_result is not skipped
 
 - name: Chromedriver tasks
   ansible.builtin.import_tasks: chromedriver.yml

--- a/roles/chrome/vars/main.yml
+++ b/roles/chrome/vars/main.yml
@@ -1,0 +1,20 @@
+---
+# Channels @puppeteer/browsers accepts; anything else is treated as a pinned version.
+chrome_release_channels: [stable, beta, dev, canary]
+
+# Dependencies renamed by the 64-bit time_t transition in Debian 13 "trixie".
+chrome_release_dependencies:
+  bookworm:
+    - libasound2
+    - libatk-bridge2.0-0
+    - libatk1.0-0
+    - libatspi2.0-0
+    - libcups2
+    - libglib2.0-0
+  trixie:
+    - libasound2t64
+    - libatk-bridge2.0-0t64
+    - libatk1.0-0t64
+    - libatspi2.0-0t64
+    - libcups2t64
+    - libglib2.0-0t64


### PR DESCRIPTION
Closes #133.

**t64 names:** the dependencies renamed by the 64-bit time_t transition now come from a per-release map in `vars/main.yml`. Verified against a live trixie apt database: only six packages were renamed (`libasound2`, `libatk-bridge2.0-0`, `libatk1.0-0`, `libatspi2.0-0`, `libcups2`, `libglib2.0-0`); `libdbus-1-3` and `libxtst6` kept their names and stay in the common list.

**Version race / always-run:** channel names (stable/beta/dev/canary) are resolved against the Chrome for Testing `last-known-good-versions.json` first, and the puppeteer installer only runs when the installed version differs — previously `npx @puppeteer/browsers` ran on every play and changed-ness was derived from its output afterwards. Exact version pins pass through unchanged. Same restructure for chromedriver.

The molecule scenario pins the stable version resolved in prepare, so a stable promotion between converge and the idempotence run can no longer break CI. Passes `make test ROLE=chrome` on both releases.

Non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)