### PR TITLE
yarn: document node role ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ flagged with **BREAKING** and require a MAJOR version bump.
   the `src` entries of `nginx_conf`/`nginx_snippets`/`nginx_vhosts`,
   `apache2_vhosts`, and `sudo_additional_config` resolve to `templates/<role>/...`
   directories next to the consuming playbook. (#137)
+- **yarn:** document that the `node` role must be ordered before `yarn`, because
+  the Yarn deb's `nodejs` dependency is otherwise satisfied by Debian's distro
+  Node.js rather than the NodeSource build. (#134)
 
 ### Deprecated
 

--- a/roles/yarn/README.md
+++ b/roles/yarn/README.md
@@ -2,6 +2,14 @@
 
 Installs Yarn package manager.
 
+## Requirements
+
+The Yarn 1.x deb depends on `nodejs`, and apt satisfies that with **Debian's
+distro Node.js** if none is installed yet. To run Yarn against the NodeSource
+build the [`node`](../node) role provides, order `node` **before** `yarn` in
+the playbook; a playbook that applies `yarn` first silently gets the distro
+Node.js.
+
 ## Role Variables
 
 None.


### PR DESCRIPTION
Closes #134.

The Yarn 1.x deb's `Depends: nodejs` is satisfied by Debian's distro Node.js when nothing else provides it, so a playbook ordering yarn before node silently runs Yarn on the distro build. The README now documents that the `node` role must come first.

The meta-dependency alternative from the issue is deliberately not taken — it would change behaviour for existing playbooks (pulling the NodeSource install onto hosts that only wanted yarn).

Docs only; non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)