### PR TITLE
nginx, apache2, sudo: document the playbook-relative template contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ flagged with **BREAKING** and require a MAJOR version bump.
   options enabled are idempotent. The nvm installer is bumped to v0.40.5 and the
   README no longer references a nonexistent archive checksum. (#131)
 
+### Changed
+
+- **nginx, apache2, sudo:** document the playbook-relative template contract —
+  the `src` entries of `nginx_conf`/`nginx_snippets`/`nginx_vhosts`,
+  `apache2_vhosts`, and `sudo_additional_config` resolve to `templates/<role>/...`
+  directories next to the consuming playbook. (#137)
+
 ### Deprecated
 
 - **mailhog:** upstream is archived/unmaintained, the binary download is unverified

--- a/roles/apache2/README.md
+++ b/roles/apache2/README.md
@@ -15,3 +15,10 @@ Installs and configures Apache2 web server with virtual hosts and modules.
 | `apache2_modules` | `[proxy_fcgi, setenvif, rewrite, headers, ssl]` | Modules to enable |
 | `apache2_disable_modules` | `[mpm_prefork]` | Modules to disable |
 | `apache2_env_vars` | `{}` | Environment variables to set |
+
+## Templates
+
+The `src` of each `apache2_vhosts` entry is resolved relative to the consuming
+playbook, so the vhost templates must live next to it in
+`templates/apache2/vhosts/`. See this role's molecule scenario
+(`molecule/default/templates/`) for a working example.

--- a/roles/nginx/README.md
+++ b/roles/nginx/README.md
@@ -15,3 +15,11 @@ Installs and configures Nginx web server.
 | `nginx_server_tokens` | `off` | Show/hide server version |
 | `nginx_certbot_plugin` | `false` | Install Certbot Nginx plugin |
 | `nginx_client_max_body_size` | `8m` | Maximum client request body size |
+
+## Templates
+
+The `src` of each `nginx_conf`, `nginx_snippets`, and `nginx_vhosts` entry is
+resolved relative to the consuming playbook, so the templates must live next
+to it in `templates/nginx/conf/`, `templates/nginx/snippets/`, and
+`templates/nginx/vhosts/` respectively. See this role's molecule scenario
+(`molecule/default/templates/`) for a working example.

--- a/roles/sudo/README.md
+++ b/roles/sudo/README.md
@@ -7,3 +7,10 @@ Configures sudo with additional sudoers files.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `sudo_additional_config` | `[]` | Additional sudoers configuration files |
+
+## Templates
+
+The `src` of each `sudo_additional_config` entry is resolved relative to the
+consuming playbook, so the sudoers templates must live next to it in
+`templates/sudo/`. See this role's molecule scenario
+(`molecule/default/templates/`) for a working example.


### PR DESCRIPTION
Partially addresses #137 (leave open after merge).

nginx (`nginx_conf`/`nginx_snippets`/`nginx_vhosts` — the issue only listed vhosts), apache2 (`apache2_vhosts`), and sudo (`sudo_additional_config`) resolve template `src` relative to the consuming playbook. Each README now states the expected `templates/<role>/...` path and points at the role's molecule scenario as a working example.

The php_fpm, phpbu and symfony_params parts of #137 are deferred with the planned PHP refactor, so the issue stays open.

Docs only; non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)