### PR TITLE
Release v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-07-14
+
 ### Added
 
 - **pgsql:** support PostgreSQL 17 and 18: config templates for both majors,

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 5.1.0
+version: 5.2.0
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
Promotes [Unreleased] to 5.2.0 (2026-07-14) and bumps galaxy.yml.

MINOR release: new mailpit role, PostgreSQL 17/18 support, service enable/start and chrome/t64 fixes, mailhog deprecation. No breaking changes.

After merge: tag v5.2.0 on main to publish the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)