### PR TITLE
symfony_params: document variables and the template contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
   `phpbu_phar_checksum` and `phpbu_schema_url`. See `docs/migrating-v6.md`.
   (#127)
 - **chrome:** fail fast with a clear error if Node.js (npx) is not installed.
+- **symfony_params:** the README documents the role variables and the
+  playbook-relative `templates/symfony-params/` contract. (#137)
 - **meta:** `make test` and CI run every molecule scenario a role ships
   (`molecule test --all`); `make test` accepts `SCENARIO=<name>`.
 

--- a/roles/symfony_params/README.md
+++ b/roles/symfony_params/README.md
@@ -1,3 +1,19 @@
 # symfony_params
 
-Configures Symfony parameters.
+Writes a Symfony `parameters.yaml` from a consumer-supplied template.
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `symfony_params_template` | — | Template filename to render; the role no-ops when unset |
+| `symfony_params_file_path` | — (required when the template is set) | Directory the parameters file is written to (created `0750`) |
+| `symfony_params_file_user` | — (required when the template is set) | Owner of the directory and file |
+| `symfony_params_file_group` | — (required when the template is set) | Group of the directory and file |
+
+## Templates
+
+`symfony_params_template` is resolved relative to the consuming playbook, so
+the template must live next to it in `templates/symfony-params/`. It is
+rendered to `{{ symfony_params_file_path }}/parameters.yaml`. See this role's
+molecule scenario (`molecule/default/templates/`) for a working example.


### PR DESCRIPTION
Closes #137.

Adds the missing README documentation for `symfony_params`: a variables table (`symfony_params_template` no-ops when unset; the file path/user/group are required once it is set) and a Templates section for the playbook-relative `templates/symfony-params/` contract, pointing at the molecule scenario as a working example.

This was the last role from #137 without the contract documented — nginx, apache2, php and sudo already carry it, and phpbu's landed in #159.

Docs-only; `make lint` clean.

Second PR of the v6.0.0 close-out stack (137 → 138 → 135 → 136 → 128 → 139).

🤖 Generated with [Claude Code](https://claude.com/claude-code)