### PR TITLE
base, exim4: prefix the remaining unprefixed variables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ Variables defined in roles must use the role name as a prefix:
 - `base_system_packages` (not `system_packages`)
 - `nginx_worker_processes` (not `worker_processes`)
 - `chrome_chromedriver_version` (not `chromedriver_version`)
-There are existing roles that break this convention. They will be refactored.
+One deliberate exception remains: `aws_config`'s eponymous `aws_config`
+variable.
 
 ### Task Naming
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,14 @@ flagged with **BREAKING** and require a MAJOR version bump.
   the better), and `pgsql_wal_compression` is `lz4` (stock off; compresses
   WAL full-page images, safe on existing clusters as it only affects newly
   written WAL). The README gains a per-variable tuning guide. (#128)
+- **base:** **BREAKING** — the remaining unprefixed variables are renamed
+  with a `base_` prefix (`system_locales`, `system_default_locale`,
+  `system_timezone`, `system_packages`, `dns_primary_nameserver`,
+  `dns_secondary_nameserver`, `default_users`, `users`, `local_hostnames`,
+  `known_hosts`, `ssh_extra_user_groups`, `ssh_allow_tcp_forwarding` →
+  `base_<same>`). Rename table in `docs/migrating-v6.md`. (#139)
+- **exim4:** **BREAKING** — `mailname` is renamed to `exim4_mailname`. See
+  `docs/migrating-v6.md`. (#139)
 
 ### Removed
 

--- a/docs/migrating-v6.md
+++ b/docs/migrating-v6.md
@@ -302,6 +302,28 @@ Files that previously ended up stricter than `0644` will be loosened unless
 the item sets `mode` — set `mode: "0600"` explicitly on files carrying
 secrets.
 
+## phpbu: version-pinned, GPG-verified install
+
+The phar (now 6.0.33) and its `.asc` signature are downloaded from the GitHub
+release and verified against the signing key shipped with the role before
+install. The install is pinned by a single variable:
+
+| Old | New |
+|-----|-----|
+| `phpbu_phar_url` | removed — derived from `phpbu_version` |
+| `phpbu_phar_checksum` | removed — replaced by GPG signature verification |
+| `phpbu_schema_url` | removed — derived from `phpbu_version` |
+| — | `phpbu_version` (default `6.0.33`) |
+
+If you overrode any of the removed variables to pin a different release, set
+`phpbu_version` instead. The role also gained an uninstall entrypoint:
+
+```yaml
+- ansible.builtin.import_role:
+    name: tborealis.roles.phpbu
+    tasks_from: remove
+```
+
 ## rrsync: role removed
 
 Since Debian bookworm, rsync ships `/usr/bin/rrsync` as a first-class binary,

--- a/docs/migrating-v6.md
+++ b/docs/migrating-v6.md
@@ -326,6 +326,31 @@ modules.
 `apache2_user` (previously hardcoded `www-data`; the default is unchanged),
 and changes to it restart Apache.
 
+## base and exim4: variables gain role prefixes
+
+All of base's unprefixed variables are renamed with a `base_` prefix, and
+exim4's `mailname` becomes `exim4_mailname`. Rendered configs are unchanged
+when the new names carry the old values — this is a pure inventory rename.
+
+| Old | New |
+|-----|-----|
+| `system_locales` | `base_system_locales` |
+| `system_default_locale` | `base_system_default_locale` |
+| `system_timezone` | `base_system_timezone` |
+| `system_packages` | `base_system_packages` |
+| `dns_primary_nameserver` | `base_dns_primary_nameserver` |
+| `dns_secondary_nameserver` | `base_dns_secondary_nameserver` |
+| `default_users` | `base_default_users` |
+| `users` | `base_users` |
+| `local_hostnames` | `base_local_hostnames` |
+| `known_hosts` | `base_known_hosts` |
+| `ssh_extra_user_groups` | `base_ssh_extra_user_groups` |
+| `ssh_allow_tcp_forwarding` | `base_ssh_allow_tcp_forwarding` |
+| `mailname` (exim4) | `exim4_mailname` |
+
+Note that `pgsql_locale` no longer follows `system_default_locale` (see the
+pgsql section), so renaming the base variable does not cascade.
+
 ## base: dead `ssh_extra_conf_files` removed
 
 `ssh_extra_conf_files` was referenced by no task; nothing you configured

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -6,18 +6,18 @@ Base system configuration including locales, timezone, users, DNS, and essential
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `system_locales` | `["en_US.UTF-8", "en_GB.UTF-8"]` | Locales to generate |
-| `system_default_locale` | `en_GB.UTF-8` | Default system locale |
-| `system_timezone` | `Europe/London` | System timezone |
-| `system_packages` | `[]` | Additional packages to install |
-| `dns_primary_nameserver` | `1.1.1.1` | Primary DNS server |
-| `dns_secondary_nameserver` | `1.0.0.1` | Secondary DNS server |
-| `default_users` | `[]` | Default users to create |
-| `users` | `[]` | Additional users to create |
-| `local_hostnames` | `[]` | Local hostname entries |
-| `known_hosts` | `[]` | SSH known hosts entries |
-| `ssh_extra_user_groups` | `[]` | Extra groups for SSH users |
-| `ssh_allow_tcp_forwarding` | `false` | Allow SSH TCP forwarding |
+| `base_system_locales` | `["en_US.UTF-8", "en_GB.UTF-8"]` | Locales to generate |
+| `base_system_default_locale` | `en_GB.UTF-8` | Default system locale |
+| `base_system_timezone` | `Europe/London` | System timezone |
+| `base_system_packages` | `[]` | Additional packages to install |
+| `base_dns_primary_nameserver` | `1.1.1.1` | Primary DNS server |
+| `base_dns_secondary_nameserver` | `1.0.0.1` | Secondary DNS server |
+| `base_default_users` | `[]` | Default users to create |
+| `base_users` | `[]` | Additional users to create |
+| `base_local_hostnames` | `[]` | Local hostname entries |
+| `base_known_hosts` | `[]` | SSH known hosts entries |
+| `base_ssh_extra_user_groups` | `[]` | Extra groups for SSH users |
+| `base_ssh_allow_tcp_forwarding` | `false` | Allow SSH TCP forwarding |
 | `base_default_system_packages` | See defaults | Essential system packages |
 | `base_profile_config` | `[]` | Profile configuration entries |
 | `base_hosts_unsafe_writes` | `false` | Write /etc/hosts in place (for containers, where the bind mount breaks atomic renames) |

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -1,18 +1,18 @@
 ---
-system_locales:
+base_system_locales:
   - "en_US.UTF-8"
   - "en_GB.UTF-8"
-system_default_locale: en_GB.UTF-8
-system_timezone: Europe/London
-system_packages: []
-dns_primary_nameserver: 1.1.1.1
-dns_secondary_nameserver: 1.0.0.1
-default_users: []
-users: []
-local_hostnames: []
-known_hosts: []
-ssh_extra_user_groups: []
-ssh_allow_tcp_forwarding: false
+base_system_default_locale: en_GB.UTF-8
+base_system_timezone: Europe/London
+base_system_packages: []
+base_dns_primary_nameserver: 1.1.1.1
+base_dns_secondary_nameserver: 1.0.0.1
+base_default_users: []
+base_users: []
+base_local_hostnames: []
+base_known_hosts: []
+base_ssh_extra_user_groups: []
+base_ssh_allow_tcp_forwarding: false
 base_default_system_packages:
   - ssl-cert
   - acl

--- a/roles/base/molecule/default/converge.yml
+++ b/roles/base/molecule/default/converge.yml
@@ -8,27 +8,27 @@
     # Docker bind-mounts /etc/hosts, so the atomic rename in "Clean /etc/hosts"
     # fails with EBUSY; the role falls back to an in-place write.
     base_hosts_unsafe_writes: true
-    system_locales:
+    base_system_locales:
       - en_GB.UTF-8
-    system_default_locale: en_GB.UTF-8
-    system_timezone: Europe/London
+    base_system_default_locale: en_GB.UTF-8
+    base_system_timezone: Europe/London
     # cron also satisfies the role's "Restart cron" handler: the test image
     # ships without cron, and the packages task runs before the handler fires.
-    system_packages:
+    base_system_packages:
       - cron
-    dns_primary_nameserver: 9.9.9.9
-    dns_secondary_nameserver: 149.112.112.112
-    local_hostnames:
+    base_dns_primary_nameserver: 9.9.9.9
+    base_dns_secondary_nameserver: 149.112.112.112
+    base_local_hostnames:
       - molecule-base.example.invalid
-    known_hosts:
+    base_known_hosts:
       - "{{ base_molecule_known_host_entry }}"
-    ssh_extra_user_groups:
+    base_ssh_extra_user_groups:
       - sftp-users
-    ssh_allow_tcp_forwarding: true
+    base_ssh_allow_tcp_forwarding: true
     base_profile_config:
       - src: molecule-profile.sh.j2
         dest: molecule-profile.sh
-    default_users:
+    base_default_users:
       - name: molecule-admin
         password: "{{ base_molecule_admin_password_hash }}"
         groups:
@@ -36,7 +36,7 @@
           - sudo
         authorized_keys:
           - "{{ base_molecule_admin_key_file }}"
-    users:
+    base_users:
       - name: molecule-deploy
         password: "{{ base_molecule_deploy_password_hash }}"
         groups:

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -68,7 +68,7 @@
 
 - name: Install system packages
   ansible.builtin.apt:
-    pkg: "{{ base_default_system_packages + system_packages }}"
+    pkg: "{{ base_default_system_packages + base_system_packages }}"
     state: present
     update_cache: true
     cache_valid_time: 3600
@@ -77,7 +77,7 @@
   community.general.locale_gen:
     name: "{{ item }}"
     state: present
-  with_items: "{{ system_locales }}"
+  with_items: "{{ base_system_locales }}"
 
 - name: Set default locale
   ansible.builtin.template:
@@ -90,7 +90,7 @@
 
 - name: Set default timezone
   community.general.timezone:
-    name: "{{ system_timezone }}"
+    name: "{{ base_system_timezone }}"
   notify: Restart cron
 
 - name: Use full hostname in prompt
@@ -105,7 +105,7 @@
     system: true
   with_items:
     - ssh-users
-    - "{{ ssh_extra_user_groups }}"
+    - "{{ base_ssh_extra_user_groups }}"
 
 - name: Create users
   ansible.builtin.user:
@@ -115,8 +115,8 @@
     groups: "{{ item.groups }}"
     shell: "{{ item.shell | default('/bin/bash') }}"
   with_items:
-    - "{{ default_users }}"
-    - "{{ users }}"
+    - "{{ base_default_users }}"
+    - "{{ base_users }}"
   loop_control:
     label: "{{ item.name }}"
 
@@ -125,7 +125,7 @@
     user: "{{ item.name }}"
     key: "{% for key in item.authorized_keys %}{{ lookup('file', key) }}\n{% endfor %}"
     exclusive: true
-  with_items: "{{ default_users + users }}"
+  with_items: "{{ base_default_users + base_users }}"
   loop_control:
     label: "{{ item.name }}"
 
@@ -165,7 +165,7 @@
     owner: root
     group: root
     mode: "0644"
-  with_items: "{{ known_hosts }}"
+  with_items: "{{ base_known_hosts }}"
 
 - name: Add to profile.d
   ansible.builtin.template:

--- a/roles/base/templates/locale.j2
+++ b/roles/base/templates/locale.j2
@@ -1,1 +1,1 @@
-LANG="{{ system_default_locale }}"
+LANG="{{ base_system_default_locale }}"

--- a/roles/base/templates/networking/dhclient.conf.j2
+++ b/roles/base/templates/networking/dhclient.conf.j2
@@ -7,4 +7,4 @@ dhcp6.name-servers, dhcp6.domain-search, dhcp6.fqdn, dhcp6.sntp-servers,
 netbios-name-servers, netbios-scope, interface-mtu,
 rfc3442-classless-static-routes, ntp-servers;
 
-prepend domain-name-servers {{ dns_primary_nameserver }} {{ dns_secondary_nameserver }};
+prepend domain-name-servers {{ base_dns_primary_nameserver }} {{ base_dns_secondary_nameserver }};

--- a/roles/base/templates/networking/hosts.j2
+++ b/roles/base/templates/networking/hosts.j2
@@ -3,7 +3,7 @@
 #
 
 127.0.0.1 localhost
-127.0.1.1 {{ inventory_hostname_short }} {{ inventory_hostname }}{% for host in local_hostnames %}{% if host != inventory_hostname %} {{ host }}{% endif %}{% endfor %}
+127.0.1.1 {{ inventory_hostname_short }} {{ inventory_hostname }}{% for host in base_local_hostnames %}{% if host != inventory_hostname %} {{ host }}{% endif %}{% endfor %}
 
 ::1 localhost ip6-localhost ip6-loopback
 ff02::1 ip6-allnodes

--- a/roles/base/templates/ssh/99-custom.conf.j2
+++ b/roles/base/templates/ssh/99-custom.conf.j2
@@ -3,8 +3,8 @@
 #
 
 AuthorizedKeysFile	.ssh/authorized_keys
-AllowTcpForwarding {{ 'yes' if ssh_allow_tcp_forwarding else 'no' }}
+AllowTcpForwarding {{ 'yes' if base_ssh_allow_tcp_forwarding else 'no' }}
 X11Forwarding no
 UseDNS no
-AllowGroups ssh-users {{ ssh_extra_user_groups | join(' ') }}
+AllowGroups ssh-users {{ base_ssh_extra_user_groups | join(' ') }}
 DebianBanner no

--- a/roles/exim4/README.md
+++ b/roles/exim4/README.md
@@ -7,4 +7,4 @@ Installs and configures Exim4 mail transfer agent.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `exim4_sender_hostname` | `{{ inventory_hostname }}` | Sender hostname for outgoing mail |
-| `mailname` | `{{ inventory_hostname }}` | System mail name, written to `/etc/mailname` and included in exim's local domains so aliased local mail (e.g. postmaster) stays routeable |
+| `exim4_mailname` | `{{ inventory_hostname }}` | System mail name, written to `/etc/mailname` and included in exim's local domains so aliased local mail (e.g. postmaster) stays routeable |

--- a/roles/exim4/defaults/main.yml
+++ b/roles/exim4/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 exim4_sender_hostname: "{{ inventory_hostname }}"
-mailname: "{{ inventory_hostname }}"
+exim4_mailname: "{{ inventory_hostname }}"

--- a/roles/exim4/molecule/default/vars.yml
+++ b/roles/exim4/molecule/default/vars.yml
@@ -3,4 +3,4 @@
 # inventory_hostname, so explicit values prove the template actually renders
 # what it is given.
 exim4_sender_hostname: mail.molecule.test
-mailname: molecule.test
+exim4_mailname: molecule.test

--- a/roles/exim4/molecule/default/verify.yml
+++ b/roles/exim4/molecule/default/verify.yml
@@ -33,7 +33,7 @@
       ansible.builtin.assert:
         that:
           - exim4_sender_hostname in exim4_verify_local_domains.stdout
-          - mailname in exim4_verify_local_domains.stdout
+          - exim4_mailname in exim4_verify_local_domains.stdout
 
     - name: Query the configured listening interfaces
       ansible.builtin.command: exim -bP local_interfaces
@@ -54,7 +54,7 @@
       ansible.builtin.assert:
         that:
           - "\"dc_eximconfig_configtype='internet'\" in exim4_verify_conf.content | b64decode"
-          - "\"dc_other_hostnames='\" ~ exim4_sender_hostname ~ \" ; \" ~ mailname ~ \"'\" in exim4_verify_conf.content | b64decode"
+          - "\"dc_other_hostnames='\" ~ exim4_sender_hostname ~ \" ; \" ~ exim4_mailname ~ \"'\" in exim4_verify_conf.content | b64decode"
 
     - name: Read mailname
       ansible.builtin.slurp:
@@ -64,7 +64,7 @@
     - name: Assert mailname is set
       ansible.builtin.assert:
         that:
-          - exim4_verify_mailname.content | b64decode == mailname ~ "\n"
+          - exim4_verify_mailname.content | b64decode == exim4_mailname ~ "\n"
 
     # postmaster's alias to root gets qualified with /etc/mailname, so this
     # routes only because the role includes the mailname in the local domains

--- a/roles/exim4/tasks/main.yml
+++ b/roles/exim4/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Set mailname
   ansible.builtin.copy:
-    content: "{{ mailname }}\n"
+    content: "{{ exim4_mailname }}\n"
     dest: /etc/mailname
     owner: root
     group: root

--- a/roles/exim4/templates/etc/exim4/update-exim4.conf.conf.j2
+++ b/roles/exim4/templates/etc/exim4/update-exim4.conf.conf.j2
@@ -3,7 +3,7 @@
 #
 
 dc_eximconfig_configtype='internet'
-dc_other_hostnames='{{ [exim4_sender_hostname, mailname] | unique | join(' ; ') }}'
+dc_other_hostnames='{{ [exim4_sender_hostname, exim4_mailname] | unique | join(' ; ') }}'
 dc_local_interfaces='127.0.0.1 ; ::1'
 dc_readhost=''
 dc_relay_domains=''


### PR DESCRIPTION
Closes #139.

**BREAKING** — the last unprefixed variables gain role prefixes, clearing the naming debt acknowledged in AGENTS.md:

- **base**: `system_locales`, `system_default_locale`, `system_timezone`, `system_packages`, `dns_primary_nameserver`, `dns_secondary_nameserver`, `default_users`, `users`, `local_hostnames`, `known_hosts`, `ssh_extra_user_groups`, `ssh_allow_tcp_forwarding` → `base_<same>`.
- **exim4**: `mailname` → `exim4_mailname`.

Rendered configs are unchanged when the new names carry the old values — a pure inventory rename, with the full table in `docs/migrating-v6.md`. AGENTS.md now lists a single deliberate naming exception (`aws_config`'s eponymous variable).

Also includes the migration-guide section for the phpbu variable replacement that shipped in #159 (the guide file didn't exist on that branch).

Issue close-out notes for #139: the do_agent filename and PHP ini-boolean/README items were already fixed (5.2.0 / the php consolidation), and the `base_manage_hostname` toggle is deferred — the issue conditions it on container use becoming a target.

## Testing
`make lint` clean; `make test ROLE=base` and `make test ROLE=exim4` pass on bookworm and trixie.

Final PR of the v6.0.0 close-out stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)