### PR TITLE
mysql: remove deprecated InnoDB redo log variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,10 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ### Removed
 
+- **mysql:** **BREAKING** — the deprecated `mysql_innodb_log_file_size` and
+  `mysql_innodb_log_files_in_group` variables are removed and now silently
+  ignored; set `mysql_innodb_redo_log_capacity` (size × group) instead. See
+  `docs/migrating-v6.md`.
 - **rabbitmq:** the unused `Restart rabbitmq` handler — nothing in the role
   notifies it and no task writes config that would need a restart.
 - **tasks:** **BREAKING** — the shared task-file pseudo-role (`roles/tasks/`)

--- a/docs/migrating-v6.md
+++ b/docs/migrating-v6.md
@@ -492,6 +492,23 @@ The `tasks` pseudo-role (`roles/tasks/`) and its `add-key.yml` and
   `ansible.builtin.include_vars` (e.g. `with_first_found` over
   `secure_vars/<group>.yml`) if you need the pattern.
 
+## mysql: deprecated InnoDB redo log variables removed
+
+`mysql_innodb_log_file_size` and `mysql_innodb_log_files_in_group` are
+removed and now silently ignored if set. Previously they overrode
+`mysql_innodb_redo_log_capacity` (derived as `size × group`). Set
+`mysql_innodb_redo_log_capacity` to the same product instead — the default
+`256M` equals the old defaults (`128M × 2`):
+
+```yaml
+# before
+mysql_innodb_log_file_size: 512M
+mysql_innodb_log_files_in_group: 2
+
+# after
+mysql_innodb_redo_log_capacity: 1G
+```
+
 ## apache2: dead variables removed
 
 `apache2_load_modules` and `apache2_conf` are removed. They were declared and

--- a/roles/mysql/README.md
+++ b/roles/mysql/README.md
@@ -15,8 +15,3 @@ Installs and configures MySQL server.
 | `mysql_innodb_flush_log_at_trx_commit` | `1` | Flush log at commit (0 for VM performance) |
 | `mysql_slow_query_log` | `0` | Enable slow query logging |
 | `mysql_login_unix_socket` | `/var/run/mysqld/mysqld.sock` | Socket used for role logins (always matches `root@localhost`) |
-
-The deprecated `mysql_innodb_log_file_size` and `mysql_innodb_log_files_in_group`
-variables are still honoured if set (redo capacity is derived as `size × group`,
-overriding `mysql_innodb_redo_log_capacity`), but they will be removed in a future
-major release.

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -55,15 +55,6 @@
     state: stopped
   when: mysql_installed.stdout != "ii "
 
-- name: Warn about deprecated InnoDB redo log variables
-  ansible.builtin.debug:
-    msg: >-
-      DEPRECATION WARNING: mysql_innodb_log_file_size and
-      mysql_innodb_log_files_in_group are deprecated and will be removed in a
-      future major release; set mysql_innodb_redo_log_capacity (size * group)
-      instead.
-  when: mysql_innodb_log_file_size is defined or mysql_innodb_log_files_in_group is defined
-
 - name: Configure
   ansible.builtin.template:
     src: tuning.cnf.j2

--- a/roles/mysql/templates/tuning.cnf.j2
+++ b/roles/mysql/templates/tuning.cnf.j2
@@ -4,10 +4,6 @@
 [mysqld]
 innodb_buffer_pool_size        = {{ mysql_innodb_buffer_pool_size }}
 innodb_flush_log_at_trx_commit = {{ mysql_innodb_flush_log_at_trx_commit }}
-{% if mysql_innodb_log_file_size is defined or mysql_innodb_log_files_in_group is defined %}
-innodb_redo_log_capacity       = {{ (mysql_innodb_log_file_size | default('128M') | ansible.builtin.human_to_bytes) * (mysql_innodb_log_files_in_group | default(2) | int) }}
-{% else %}
 innodb_redo_log_capacity       = {{ mysql_innodb_redo_log_capacity }}
-{% endif %}
 
 slow_query_log                 = {{ mysql_slow_query_log }}


### PR DESCRIPTION
Removes `mysql_innodb_log_file_size` and `mysql_innodb_log_files_in_group`, deprecated with removal slated for the next major release — v6.0.0 is it. The tuning template now always renders `innodb_redo_log_capacity` from `mysql_innodb_redo_log_capacity`; the deprecation-warning task is gone and `docs/migrating-v6.md` gains a migration section (set the new variable to the old `size × group` product).

**BREAKING** — requires the MAJOR bump already planned for v6.0.0.

Verified: `make lint` clean; `make test ROLE=mysql` green on bookworm and trixie (converge, idempotence, verify).