### PR TITLE
Fix loop variables in task names and lint against the class

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,8 @@
 ---
 profile: production
+use_default_rules: true
+rulesdir:
+  - .config/ansible-lint-rules
 skip_list:
   - experimental
 kinds:

--- a/.config/ansible-lint-rules/loop_var_in_name.py
+++ b/.config/ansible-lint-rules/loop_var_in_name.py
@@ -1,0 +1,48 @@
+"""Rule: a task name must not reference the task's own loop variable."""
+
+from __future__ import annotations
+
+import re
+
+from ansiblelint.rules import AnsibleLintRule
+
+LOOP_KEYWORDS = ("loop", "with_items", "with_dict", "with_fileglob",
+                 "with_first_found", "with_together", "with_sequence",
+                 "with_subelements", "with_nested", "with_random_choice",
+                 "with_indexed_items", "with_ini", "with_lines", "with_list")
+
+
+class LoopVarInNameRule(AnsibleLintRule):
+    """Task name references its loop variable, which is undefined there."""
+
+    id = "loop-var-in-name"
+    shortdesc = "Task name must not reference the loop variable"
+    description = (
+        "Task names are templated once, before the loop runs, so the loop "
+        "variable is always undefined there and Ansible warns "
+        "\"'item' is undefined\". Use a static name and put per-item detail "
+        "in loop_control.label instead."
+    )
+    severity = "HIGH"
+    tags = ["idiom"]
+    version_changed = "1.0.0"
+    # Profile filtering unloads every rule whose id is not in the profile;
+    # this marker is the only way a custom rule survives `profile: production`.
+    unloadable = True
+
+    def matchtask(self, task, file=None):
+        name = task.get("name")
+        if not name or "{{" not in name:
+            return False
+        raw = getattr(task, "raw_task", None) or task
+        if not any(key in raw for key in LOOP_KEYWORDS):
+            return False
+        loop_var = "item"
+        loop_control = raw.get("loop_control")
+        if isinstance(loop_control, dict):
+            loop_var = loop_control.get("loop_var", "item")
+        pattern = re.compile(r"{{(?:(?!}}).)*\b%s\b(?:(?!}}).)*}}" % re.escape(loop_var))
+        if pattern.search(name):
+            return (f"Task name references loop variable '{loop_var}', which is "
+                    "undefined when names are templated; use loop_control.label.")
+        return False

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,12 @@ Variables defined in roles must use the role name as a prefix:
 
 ### Task Naming
 
-- Jinja templates go at the end of task names: `Install packages for {{ item.name }}`
+- Jinja templates go at the end of task names: `Install packages for {{ php_version }}`
+- Never reference a task's own loop variable in its name — names are templated once,
+  before the loop, so the variable is always undefined there. Use `loop_control.label`
+  for per-item detail. Enforced by the custom `loop-var-in-name` lint rule
+  (`.config/ansible-lint-rules/`). Include-loop vars (`include_tasks` +
+  `loop_control.loop_var`) are fine in the *included* file's task names.
 - Use FQCNs for modules: `ansible.builtin.apt`, `community.general.locale_gen`
 
 ### Ansible-lint Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ### Added
 
+- **meta:** custom ansible-lint rule `loop-var-in-name`
+  (`.config/ansible-lint-rules/`) failing the lint gate when a task's name
+  references its own loop variable — names are templated before the loop, so
+  such names always emit an "'item' is undefined" template warning at run
+  time, which molecule never fails on.
 - **node:** optional tj/n version manager (`node_version_manager: n`): extra
   Node versions cached machine-wide from official nodejs.org builds
   (`node_n_versions`, with per-version global packages and pruning of
@@ -198,6 +203,9 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ### Fixed
 
+- **node, php:** looped task names no longer reference the loop variable
+  (node's n-version assert; php's remove-other-versions tasks), which emitted
+  an "'item' is undefined" template-error warning on every run.
 - **certbot, dbcd, gpg:** READMEs rewritten to the standard variables-table
   format. dbcd's fixes the wrong variable name it documented (`dbcd_mode` →
   `dbcd_modes`), documents `dbcd_server_user`/`dbcd_data_dir`, and corrects the

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -24,7 +24,7 @@
       - node_version_manager == 'nvm' or node_nvm_config | length == 0
     fail_msg: node_nvm_config requires node_version_manager "nvm".
 
-- name: "Assert numeric n version: {{ item.version | default(item) }}"
+- name: Assert numeric n versions
   ansible.builtin.assert:
     that:
       - item.version is defined

--- a/roles/php/tasks/remove-other-versions.yml
+++ b/roles/php/tasks/remove-other-versions.yml
@@ -15,7 +15,7 @@
   ansible.builtin.service_facts:
   when: php_other_versions | length > 0
 
-- name: Stop and disable PHP FPM for other version {{ item }}
+- name: Stop and disable PHP FPM for other versions
   ansible.builtin.service:
     name: "php{{ item }}-fpm"
     state: stopped
@@ -23,7 +23,7 @@
   loop: "{{ php_other_versions }}"
   when: "'php' ~ item ~ '-fpm.service' in ansible_facts.services | default({})"
 
-- name: Purge PHP packages for other version {{ item }}
+- name: Purge PHP packages for other versions
   ansible.builtin.apt:
     pkg:
       - "php{{ item }}"
@@ -32,7 +32,7 @@
     purge: true
   loop: "{{ php_other_versions }}"
 
-- name: Remove configuration of other version {{ item }}
+- name: Remove configuration of other versions
   ansible.builtin.file:
     path: "/etc/php/{{ item }}"
     state: absent


### PR DESCRIPTION
A v6 test provision surfaced `[WARNING]: Encountered 1 template error - 'item' is undefined` from a node task name. Task names are templated once, before the loop runs, so a task's own loop variable is always undefined there — Ansible degrades it to a warning, which molecule never fails on.

- **Fix:** the four instances (node's n-version assert; php's three `remove-other-versions.yml` tasks) get static names; per-item detail stays in the loop labels. certbot's `certbot_certs_item` names are fine — include-loop vars are defined when included task names template.
- **Catch:** new custom ansible-lint rule `loop-var-in-name` (`.config/ansible-lint-rules/`) fails `make lint`/CI when a looped task's name references its own loop variable (honours `loop_control.loop_var`). Static lint over runtime detection because Ansible has no warnings-as-errors and output-grepping is fragile. Validated red-then-green: the rule flagged exactly the four real bugs before the fix. Gotcha: profile filtering unloads custom rules unless they set `unloadable = True`.

Verified: full `make lint` clean; `make test ROLE=node` and `make test ROLE=php` (all scenarios incl. `upgrade`) green on bookworm and trixie with zero template warnings.