### PR TITLE
base: only restart cron after a timezone change if it is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,10 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ### Fixed
 
+- **base:** the "Restart cron" handler (notified on timezone changes) now
+  restarts cron only when it is installed, instead of failing on images that
+  ship without cron (e.g. Debian 13 DigitalOcean droplets); base does not
+  install cron itself.
 - **node, php:** looped task names no longer reference the loop variable
   (node's n-version assert; php's remove-other-versions tasks), which emitted
   an "'item' is undefined" template-error warning on every run.

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -2,6 +2,10 @@
 
 Base system configuration including locales, timezone, users, DNS, and essential packages.
 
+The role does not install cron. When cron is present it is restarted after a
+timezone change so scheduled jobs pick up the new zone; on images without cron
+(e.g. DigitalOcean's Debian 13) the restart is skipped.
+
 ## Role Variables
 
 | Variable | Default | Description |

--- a/roles/base/handlers/main.yml
+++ b/roles/base/handlers/main.yml
@@ -1,9 +1,17 @@
 ---
+- name: Gather service facts for cron restart
+  ansible.builtin.service_facts:
+  listen: Restart cron
+
+# Base does not install cron; skip the restart on images without it (e.g.
+# DigitalOcean's Debian 13 no longer ships cron).
 - name: Restart cron
   ansible.builtin.service:
     name: cron
     state: restarted
     enabled: true
+  when: "'cron.service' in ansible_facts.services"
+  listen: Restart cron
 
 - name: Reload sshd
   ansible.builtin.service:

--- a/roles/base/molecule/default/converge.yml
+++ b/roles/base/molecule/default/converge.yml
@@ -12,10 +12,10 @@
       - en_GB.UTF-8
     base_system_default_locale: en_GB.UTF-8
     base_system_timezone: Europe/London
-    # cron also satisfies the role's "Restart cron" handler: the test image
-    # ships without cron, and the packages task runs before the handler fires.
-    base_system_packages:
-      - cron
+    # The test images ship without cron. Install it on bookworm only, mirroring
+    # the real DO images, so both handler paths are exercised: restart on
+    # bookworm, skip on trixie.
+    base_system_packages: "{{ ['cron'] if ansible_facts['distribution_release'] == 'bookworm' else [] }}"
     base_dns_primary_nameserver: 9.9.9.9
     base_dns_secondary_nameserver: 149.112.112.112
     base_local_hostnames:

--- a/roles/base/molecule/default/verify.yml
+++ b/roles/base/molecule/default/verify.yml
@@ -70,16 +70,27 @@
           - "'htop' in ansible_facts.packages"
           - "'zstd' in ansible_facts.packages"
           - "'openssh-server' in ansible_facts.packages"
-          - "'cron' in ansible_facts.packages"
 
     - name: Gather service facts
       ansible.builtin.service_facts:
 
-    - name: Assert cron and sshd are running
+    - name: Assert sshd is running
       ansible.builtin.assert:
         that:
-          - ansible_facts.services['cron.service'].state == 'running'
           - ansible_facts.services['ssh.service'].state == 'running'
+
+    - name: Assert cron was installed and restarted (bookworm)
+      ansible.builtin.assert:
+        that:
+          - "'cron' in ansible_facts.packages"
+          - ansible_facts.services['cron.service'].state == 'running'
+      when: ansible_facts['distribution_release'] == 'bookworm'
+
+    - name: Assert the cron restart was skipped on a cron-less image (trixie)
+      ansible.builtin.assert:
+        that:
+          - "'cron' not in ansible_facts.packages"
+      when: ansible_facts['distribution_release'] == 'trixie'
 
     - name: Read the passwd database
       ansible.builtin.getent:


### PR DESCRIPTION
## Summary

Fresh provisions on Debian 13 DigitalOcean droplets failed in the base role's `Restart cron` handler with `Could not find the requested service cron` — DO's trixie images no longer preinstall cron (the bookworm ones did).

- The handler now gathers service facts via `listen: Restart cron` and skips the restart when `cron.service` is absent; base neither installs nor requires cron.
- Molecule converge installs cron on bookworm only, mirroring the real DO images, so both handler paths are exercised; verify asserts cron running on bookworm and absent on trixie.
- README note + changelog entry (not breaking).

Related: #172 tracks monitoring DO base images for package-manifest changes so the next image slimming doesn't surprise us.

## Testing

- `make lint` — passes (production profile)
- `make test ROLE=base DISTRO=trixie` and `DISTRO=bookworm` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)