### PR TITLE
Release v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [6.0.0] - 2026-07-20
+
 ### Added
 
 - **meta:** custom ansible-lint rule `loop-var-in-name`

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 5.2.0
+version: 6.0.0
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
Cuts the v6.0.0 major release: bumps `galaxy.yml` to 6.0.0 and promotes the `[Unreleased]` changelog section to `## [6.0.0] - 2026-07-20`.

Highlights (full details in `CHANGELOG.md`, migration guide in `docs/migrating-v6.md`):

- Consolidated roles: `php` (replaces php_repo_sury/php_cli/php_fpm/composer/new_relic), `aws` (aws_cli/aws_config), `node` (absorbs nvm/yarn), `pgsql` (absorbs pgsql_client), `env_file` (replaces dotenv/environment)
- Removed roles: mailhog, rrsync, the `tasks` pseudo-role
- **BREAKING** variable renames: `base_*`/`exim4_mailname` prefixes, `postgres_*` → `pgsql_*`, `certbot_apache2_ssl_vhosts`, plus removal of deprecated mysql InnoDB redo-log variables and dead vars (#138)

After merge: `git tag v6.0.0 && git push origin v6.0.0` to publish the GitHub Release.