### PR TITLE
Release v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [6.1.0] - 2026-08-05
+
 ### Added
 
 - **certbot:** new `dns-cloudflare` mode — DNS-01 validation via a Cloudflare

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 6.0.0
+version: 6.1.0
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
Cuts release v6.1.0 (MINOR): promotes the certbot `dns-cloudflare` mode (#177) from Unreleased and bumps `galaxy.yml` to 6.1.0.

After merge: `git tag v6.1.0 && git push origin v6.1.0` to publish the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)