### PR TITLE
certbot: per-plugin DNS propagation wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+### Added
+
+- **certbot:** per-plugin DNS propagation wait, passed as
+  `--dns-<plugin>-propagation-seconds` on certificate creation:
+  `certbot_digitalocean_dns_propagation_seconds` (default `10`, matching the
+  upstream plugin default) and `certbot_cloudflare_dns_propagation_seconds`
+  (default `30`, raised from the upstream 10s which is too short for
+  Cloudflare). Applies to newly created certificates only; existing
+  certificates keep the propagation value saved in their renewal config.
+
 ## [6.1.0] - 2026-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ flagged with **BREAKING** and require a MAJOR version bump.
   `certbot_digitalocean_dns_propagation_seconds` (default `10`, matching the
   upstream plugin default) and `certbot_cloudflare_dns_propagation_seconds`
   (default `30`, raised from the upstream 10s which is too short for
-  Cloudflare). Applies to newly created certificates only; existing
-  certificates keep the propagation value saved in their renewal config.
+  Cloudflare). Existing certificates are updated too, so the value also
+  applies to renewals of already-issued certificates — via `certbot
+  reconfigure` on trixie, or by editing the renewal config directly on
+  bookworm (whose certbot predates `reconfigure`).
 
 ## [6.1.0] - 2026-08-05
 

--- a/roles/certbot/README.md
+++ b/roles/certbot/README.md
@@ -27,6 +27,8 @@ Installs certbot and requests Let's Encrypt certificates in one of four modes:
 | `certbot_apache2_ssl_vhosts` | `apache2_vhosts` if defined, else `[]` | `apache` mode only: SSL vhosts to install once certificates exist; see below |
 | `certbot_digitalocean_dns_token` | Required in `dns-digitalocean` mode | DigitalOcean API token with all `domain` scopes |
 | `certbot_cloudflare_dns_token` | Required in `dns-cloudflare` mode | Cloudflare API token with Zone → DNS → Edit on the certificates' zones |
+| `certbot_digitalocean_dns_propagation_seconds` | `10` | Seconds to wait for DNS propagation before asking the ACME server to verify the record |
+| `certbot_cloudflare_dns_propagation_seconds` | `30` | Seconds to wait for DNS propagation before asking the ACME server to verify the record |
 
 ## Certificates
 

--- a/roles/certbot/defaults/main.yml
+++ b/roles/certbot/defaults/main.yml
@@ -2,3 +2,5 @@
 certbot_certs: []
 certbot_dry_run: false
 certbot_apache2_ssl_vhosts: "{{ apache2_vhosts | default([]) }}"
+certbot_digitalocean_dns_propagation_seconds: 10
+certbot_cloudflare_dns_propagation_seconds: 30

--- a/roles/certbot/tasks/dns-cloudflare-certs.yml
+++ b/roles/certbot/tasks/dns-cloudflare-certs.yml
@@ -4,6 +4,7 @@
     certbot certonly
     --dns-cloudflare
     --dns-cloudflare-credentials /etc/letsencrypt/cloudflare.ini
+    --dns-cloudflare-propagation-seconds {{ certbot_cloudflare_dns_propagation_seconds }}
     --non-interactive
     --agree-tos
     --email "{{ certbot_certs_item.admin_email }}"

--- a/roles/certbot/tasks/dns-cloudflare-certs.yml
+++ b/roles/certbot/tasks/dns-cloudflare-certs.yml
@@ -14,3 +14,9 @@
     {{ certbot_dry_run | ternary('--dry-run', '') }}
   args:
     creates: "/etc/letsencrypt/live/{{ certbot_certs_item.name }}/cert.pem"
+
+- name: "Apply propagation seconds to renewal config for {{ certbot_certs_item.name }}"
+  ansible.builtin.include_tasks: dns-propagation.yml
+  vars:
+    certbot_propagation_plugin: cloudflare
+    certbot_propagation_seconds: "{{ certbot_cloudflare_dns_propagation_seconds }}"

--- a/roles/certbot/tasks/dns-digitalocean-certs.yml
+++ b/roles/certbot/tasks/dns-digitalocean-certs.yml
@@ -14,3 +14,9 @@
     {{ certbot_dry_run | ternary('--dry-run', '') }}
   args:
     creates: "/etc/letsencrypt/live/{{ certbot_certs_item.name }}/cert.pem"
+
+- name: "Apply propagation seconds to renewal config for {{ certbot_certs_item.name }}"
+  ansible.builtin.include_tasks: dns-propagation.yml
+  vars:
+    certbot_propagation_plugin: digitalocean
+    certbot_propagation_seconds: "{{ certbot_digitalocean_dns_propagation_seconds }}"

--- a/roles/certbot/tasks/dns-digitalocean-certs.yml
+++ b/roles/certbot/tasks/dns-digitalocean-certs.yml
@@ -4,6 +4,7 @@
     certbot certonly
     --dns-digitalocean
     --dns-digitalocean-credentials /etc/letsencrypt/digitalocean.ini
+    --dns-digitalocean-propagation-seconds {{ certbot_digitalocean_dns_propagation_seconds }}
     --non-interactive
     --agree-tos
     --email "{{ certbot_certs_item.admin_email }}"

--- a/roles/certbot/tasks/dns-propagation.yml
+++ b/roles/certbot/tasks/dns-propagation.yml
@@ -1,0 +1,42 @@
+---
+- name: "Check renewal config for {{ certbot_certs_item.name }}"
+  ansible.builtin.stat:
+    path: "/etc/letsencrypt/renewal/{{ certbot_certs_item.name }}.conf"
+  register: certbot_renewal_conf
+
+# Bookworm's certbot 2.1 predates `certbot reconfigure`, so the renewal config
+# is edited directly. Drop this task when bookworm support is dropped.
+- name: "Set propagation seconds in renewal config for {{ certbot_certs_item.name }}"
+  community.general.ini_file:
+    path: "/etc/letsencrypt/renewal/{{ certbot_certs_item.name }}.conf"
+    section: renewalparams
+    option: "dns_{{ certbot_propagation_plugin }}_propagation_seconds"
+    value: "{{ certbot_propagation_seconds }}"
+    mode: "0644"
+  when:
+    - ansible_facts['distribution_major_version'] | int < 13
+    - certbot_renewal_conf.stat.exists
+
+- name: "Read renewal config for {{ certbot_certs_item.name }}"
+  ansible.builtin.slurp:
+    src: "/etc/letsencrypt/renewal/{{ certbot_certs_item.name }}.conf"
+  register: certbot_renewal_conf_content
+  when:
+    - ansible_facts['distribution_major_version'] | int >= 13
+    - certbot_renewal_conf.stat.exists
+
+# reconfigure validates the new value with a dry run against the staging
+# server, so it only runs when the stored value differs.
+- name: "Set propagation seconds via reconfigure for {{ certbot_certs_item.name }}"
+  ansible.builtin.command: >
+    certbot reconfigure
+    --cert-name "{{ certbot_certs_item.name }}"
+    --dns-{{ certbot_propagation_plugin }}-propagation-seconds {{ certbot_propagation_seconds }}
+    --non-interactive
+  changed_when: true
+  when:
+    - ansible_facts['distribution_major_version'] | int >= 13
+    - certbot_renewal_conf.stat.exists
+    - >-
+      ('dns_' ~ certbot_propagation_plugin ~ '_propagation_seconds = ' ~ certbot_propagation_seconds)
+      not in certbot_renewal_conf_content.content | b64decode


### PR DESCRIPTION
## Summary

- Adds per-plugin DNS propagation variables, passed as `--dns-<plugin>-propagation-seconds` on certificate creation:
  - `certbot_digitalocean_dns_propagation_seconds` (default `10`, matching the upstream plugin default — no behaviour change)
  - `certbot_cloudflare_dns_propagation_seconds` (default `30`, raised from the upstream 10s which is too short for Cloudflare)
- Existing certificates are updated too, so the value also applies to renewals of already-issued certs. On trixie this uses `certbot reconfigure` (guarded so it only runs when the stored value differs, since reconfigure dry-runs against staging); bookworm's certbot 2.1 predates `reconfigure`, so there the renewal config's `[renewalparams]` is edited directly — a single clearly-marked task to drop along with bookworm support.

Not breaking: new variables with defaults; only the Cloudflare wait changes (10s → 30s).

## Test plan

- `make lint` passes (production profile)
- `make test ROLE=certbot` passes (issuance itself can't run in a container, so the new tasks are unexercised there, same as `certonly`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)