### PR TITLE
Release v6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ flagged with **BREAKING** and require a MAJOR version bump.
 
 ## [Unreleased]
 
+## [6.2.0] - 2026-08-06
+
 ### Added
 
 - **certbot:** per-plugin DNS propagation wait, passed as

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: tborealis
 name: roles
-version: 6.1.0
+version: 6.2.0
 readme: README.md
 authors:
   - Tom Borealis <tom@lampbristol.com>


### PR DESCRIPTION
Cuts v6.2.0: bumps `galaxy.yml` and promotes `[Unreleased]` to `## [6.2.0] - 2026-08-06`.

Contains: **certbot** per-plugin DNS propagation wait (#179) — MINOR, no breaking changes.

After merge: tag `v6.2.0` on main to trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)